### PR TITLE
Sidebar Import Fix

### DIFF
--- a/aitandem/components/__init__.py
+++ b/aitandem/components/__init__.py
@@ -2,7 +2,6 @@ from .base_layout import base_layout
 from .chat_window import chat_window_default
 from .login_window import login_window_default
 from .settings_window import settings_window_default
-from .sidebar import sidebar_default
 from .error_box import error_popup
 from .user_roles import get_user_role
 
@@ -11,7 +10,6 @@ __all__ = [
     "chat_window_default",
     "login_window_default",
     "settings_window_default",
-    "sidebar_default",
     "error_popup",
     "get_user_role",
 ]


### PR DESCRIPTION
Resolves issue #52 

- Simply removes the import in /components/_ _init_ _.py which causes the error.

Perhaps we should move sidebar.py to /components in the future again.