### PR TITLE
Add Prompt Element To Exercise

### DIFF
--- a/aitandem/pages/add_excercises.py
+++ b/aitandem/pages/add_excercises.py
@@ -347,7 +347,7 @@ def add_exercise_button() -> rx.Component:
                             type="button",
                         ),
                         rx.text(
-                            "Drag and drop or click on the button to select",
+                            "Drag and drop or click the button to select",
                         ),
                         rx.text(rx.selected_files("upload1"), color="yellow", size="3"),
                         align="center",


### PR DESCRIPTION
(Hopefully) resolves issue #38 

Adds a new area in the add-exercise page (in the Add Exercise form) where a single PDF can be selected per drag & drop, or with the "Select File" button.
![image](https://github.com/user-attachments/assets/9ea1fe6b-966c-40f1-bfe6-e3342cd4fa76)


The selected file will appear under the area in green text and a file icon. Depending on the file size, this could take some time. It can be unstaged with the red cross button again.
![image](https://github.com/user-attachments/assets/aacb35b1-8d2a-45df-aa28-7aec341512b3)


The file will not be stored locally, instead it will be extracted with pdfplumber, edited to make it somewhat more compact and then stored as a string.
The exercise title, description and the extracted PDF file will be used in the prompt template:
![image](https://github.com/user-attachments/assets/53345b92-5b30-4077-99b0-b685ab2da6d1)



Notes:
- This feature needs "pdfplumber" and "io" as imports.
- Only 1 PDF file can be selected right now
- I have some concerns that the token limit for the LLM will be reached depending on the PDF file size
- I have no idea how well the prompt works or if its works at all. I never did any prompt engineering and was not able to test this, since the chat function is currently not live on the main branch.


