### PR TITLE
relocate color mode button

### DIFF
--- a/aitutor/pages/navbar.py
+++ b/aitutor/pages/navbar.py
@@ -181,7 +181,6 @@ def navbar_default() -> rx.Component:
     """
     return rx.box(
         rx.desktop_only(
-            rx.color_mode.button(position="bottom-left", type="button"),
             rx.hstack(
                 rx.hstack(
                     rx.image(
@@ -199,13 +198,15 @@ def navbar_default() -> rx.Component:
                     *[navbar_link(text, url) for text, url in links],
                     spacing="5",
                 ),
-                profile_menu(),
+                rx.hstack(
+                    rx.color_mode.button(),
+                    profile_menu(),
+                ),
                 justify="between",
                 align_items="center",
             ),
         ),
         rx.mobile_and_tablet(
-            rx.color_mode.button(position="bottom-left", type="button"),
             rx.hstack(
                 rx.hstack(
                     rx.image(
@@ -220,6 +221,7 @@ def navbar_default() -> rx.Component:
                     align_items="center",
                 ),
                 rx.hstack(
+                    rx.color_mode.button(),
                     rx.menu.root(
                         rx.menu.trigger(
                             rx.icon("menu", size=30),


### PR DESCRIPTION
I moved the color mode button next to the user menu in the navbar. I decided not to put it inside the menu because the size of the color mode button is either too small or too large for the user menu icons. So it would look weird.

![grafik](https://github.com/user-attachments/assets/defc66e5-dc4d-458b-a4c6-8e821d65ef38)
![grafik](https://github.com/user-attachments/assets/cf4b503c-cf30-4119-a92d-fb841ba5fe85)
