### PR TITLE
Samu/bugfix

### DIFF
--- a/aitutor/pages/add_excercises.py
+++ b/aitutor/pages/add_excercises.py
@@ -767,9 +767,16 @@ def edit_exercise(exercise: Exercise):
                         rx.popover.content(
                             rx.flex(
                                 rx.text(
-                                    ExerciseState.prompts[
-                                        ExerciseState.current_prompt_name
-                                    ],
+                                    # show the prompt from the db or
+                                    # the selected prompt template
+                                    rx.cond(
+                                        ExerciseState.current_exercise.prompt_name
+                                        == ExerciseState.current_prompt_name,
+                                        ExerciseState.current_exercise.prompt,
+                                        ExerciseState.prompts[
+                                            ExerciseState.current_prompt_name
+                                        ],
+                                    ),
                                     padding="1em",
                                 ),
                                 style={


### PR DESCRIPTION
resolves #98 

# Changes
There was a bug that the prompt saved to the database did not have the correct title and description that were given to that exercise. 
This was because of a state variable `current_prompt`. 
I removed this variable and every displayed prompt now gets displayed by getting the correct prompt template with `prompts[current_prompt_name]`
Only in `edit_exercise` it shows the prompt from the database if the prompt selected is the prompt saved in the database. 
If there is a different prompt selected than saved in the database it shows the prompt template (without title, etc. filled in) when clicking on the info icon. 
In `add_exercise` it always just shows the template.