### PR TITLE
Samu/filter check result

### DIFF
--- a/aitutor/pages/chat.py
+++ b/aitutor/pages/chat.py
@@ -285,18 +285,6 @@ class ChatState(SessionState):
             # Save conversation to database.
             self.save_conversation_to_db(conversation=messages)
 
-    def check_not_passed_error(self):
-        """
-        show error if check is not passed.
-        """
-        return rx.toast.error(
-            title="Check Conversation",
-            description="The AI tutor thinks the exercise is not solved yet.",
-            duration=2500,
-            position="bottom-center",
-            invert=True,
-        )
-
     def successfull_submit_message(self):
         """
         show success message if check is passed.
@@ -326,13 +314,16 @@ class ChatState(SessionState):
             if check_conversation_response
             else False
         )
-        if not self.check_passed:
-            yield self.check_not_passed_error()
 
         # show explanation of the check in the chat
+        check_status: str = (
+            "✅ Check Passed" if self.check_passed else "❌ Check Failed"
+        )
         if check_conversation_response is not None:
             self.append_chat_message(
-                message="# Result of Check Conversation: \n"
+                message="# Result of Check Conversation: "
+                + check_status
+                + "\n"
                 + "🛈 _this result is not part of the conversation_ \n\n\n"
                 + check_conversation_response.explanation,
                 is_llm=True,
@@ -444,7 +435,7 @@ def message_box(chat_message: ChatMessage) -> rx.Component:
     check_result_color = rx.cond(
         chat_message.check_passed,
         "green",
-        "red",
+        "yellow",
     )
     return rx.box(
         rx.box(


### PR DESCRIPTION
resolves #108 

# Changes
- The Results of Check Conversation are not getting passed to the AI anymore
   - this is done by adding a role "check_result" to the dictionary and filtering out messages with this role
   - in the ChatMessage class I added a is_check_result field for this
- the Results are color coded with green or red boxes depending on if the check is passed or not
![grafik](https://github.com/user-attachments/assets/109c39cd-7ab0-4f0b-a04f-9b29663acbe4)
![grafik](https://github.com/user-attachments/assets/b44fa9cf-4a5d-44da-98a3-572de92d406a)
   - this is done by storing if the check is passed or not in the dictionary where the result message is stored.