### PR TITLE
fix: Cast exercise id from URL to int

### DIFF
--- a/aitutor/pages/finished_view/state.py
+++ b/aitutor/pages/finished_view/state.py
@@ -27,7 +27,7 @@ class FinishedViewState(SessionState):
         """Loads the finished exercise."""
         with rx.session() as session:
             exercise = session.exec(
-                Exercise.select().where(Exercise.id == self.exercise_id)
+                Exercise.select().where(Exercise.id == int(self.exercise_id))
             ).one_or_none()
             if exercise:
                 self.current_exercise = exercise


### PR DESCRIPTION
The `exercise_id` here is extracted from the pages URL (using dynamic routing), so it is of type str.  However, when using PostreSQL, types need to match in the comparison of the `where` function.