### PR TITLE
remove the 'built with reflex' badge

### DIFF
--- a/rxconfig.py
+++ b/rxconfig.py
@@ -15,4 +15,5 @@ config = rx.Config(
         "__pycache__/*",
     ],
     telemetry_enabled=False,
+    show_built_with_reflex=False,
 )


### PR DESCRIPTION
I found out how to remove this annoying badge:
![grafik](https://github.com/user-attachments/assets/aea53041-3f8e-4657-9d7d-4f53935ef0d0)
So I disabled it in the rx.config file