### PR TITLE
Load exercise with single join-query

### DIFF
--- a/aitutor/pages/exercises/state.py
+++ b/aitutor/pages/exercises/state.py
@@ -1,6 +1,7 @@
 """State for the exercises page."""
 
 import reflex as rx
+import reflex_local_auth
 from sqlmodel import and_, select
 from typing import Optional
 
@@ -41,6 +42,10 @@ class ExercisesState(SessionState):
         """
         Fetch exercises from database
         """
+        # protect data against unauthorized access
+        if not self.is_authenticated:
+            return reflex_local_auth.LoginState.redir
+
         with rx.session() as session:
             stmt = select(Exercise, ExerciseResult).join(
                 ExerciseResult,
@@ -50,7 +55,7 @@ class ExercisesState(SessionState):
                 ),
                 isouter=True,
             )
-            assert self.user_role is not None, "User role must be set."
+            assert self.user_role is not None, "User role not set.  This is a bug."
             if self.user_role < UserRole.TEACHER:
                 stmt = stmt.where(Exercise.is_hidden == False)  # noqa: E712
 


### PR DESCRIPTION
_This one still bothered me (one thing Prof. Grust hammered into us in the DB lectures was to never do stuff yourself that the database can do for you :D), so I took another try and I think it's working now._

Bring back the single query for loading the exercises, with a change that should fix the issue we had previously:
Instead of filtering for the user in a WHERE clause, add it as additional join condition in ON.

Tested with a set of three exercises:
- one which multiple users, including the logged in one, had results for
- one where an other user had results but not the logged in one (this one was causing issues previously)
- one that no user had touched.

All three exercises where displayed correctly to the logged in user with no duplicates.
But just in case it would be nice if you could test as well.