### PR TITLE
Samuel/presort data

### DIFF
--- a/aitutor/pages/exercises/state.py
+++ b/aitutor/pages/exercises/state.py
@@ -57,7 +57,9 @@ class ExercisesState(SessionState):
             if self.user_role < UserRole.TEACHER:
                 stmt = stmt.where(Exercise.is_hidden == False)  # noqa: E712
 
-            exercises_with_result = session.exec(stmt).all()
+            exercises_with_result = session.exec(
+                stmt.order_by(Exercise.id.desc())  # type: ignore
+            ).all()
             self.has_exercises = len(exercises_with_result) > 0
             self.has_tags = any(
                 len(exercise.tags) > 0 for exercise, _ in exercises_with_result

--- a/aitutor/pages/manage_exercises/state.py
+++ b/aitutor/pages/manage_exercises/state.py
@@ -184,7 +184,9 @@ class ManageExercisesState(SessionState):
                         ],
                     )
                 )
-            self.exercises = list(session.exec(query_exercises).all())
+            self.exercises = list(
+                session.exec(query_exercises.order_by(Exercise.id.desc())).all()  # type: ignore
+            )
 
     @rx.event
     def load_tags(self):

--- a/aitutor/pages/submissions/state.py
+++ b/aitutor/pages/submissions/state.py
@@ -63,7 +63,7 @@ class SubmissionsState(SessionState):
                     ),
                     isouter=True,
                 )
-            )
+            ).order_by(LocalUser.username)
             self.table_rows = [
                 (
                     TableRow(


### PR DESCRIPTION
resolves #150 

# Changes
- **exercises page**: the exercises get sorted by id in descending order
- **manage page**: the exercises get sorted by id in descending order
- **submissions page**: the rows get sorted by username in alphabetical order

# Info
#type ignore is needed because the linter complains about the `.desc()`. But the code works anyways