### PR TITLE
fix: Work around Reflex form_data not being up to date

### DIFF
--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -268,14 +268,16 @@ class ChatState(SessionState):
                 return
             self.waiting_for_response = True
 
-        user_message = form_data.get("user_response")
-        if user_message:
+        if self.user_input:
             async with self:
                 self.append_chat_message(
-                    message=user_message, role=Role.USER, check_passed=self.check_passed
+                    message=self.user_input,
+                    role=Role.USER,
+                    check_passed=self.check_passed,
                 )
                 self.user_input = ""
             yield
+
             # Takes list of ChatMessage and turns into a list of dictionaries, so
             # the OpenAI API can handle the messages.
             messages = self.get_messages_dict_gpt()


### PR DESCRIPTION
There was an issue that when writing text and then sending very fast (e.g. by hitting enter immediately), the latest changes of the written text where not yet included in the data that is passed to the `on_submit` event of the form.  This means that when using enter to submit, the last few words or changes could be missing from the message.

I believe this to be an issue with Reflex itself, so probably not much we can do to fix it.  However, we can work around it by not accessing the user input via the `form_data` that is passed to the event, but instead use `ChatState.user_input`, which is filled by the on_change event of the text area. At least in the tests I did, this seemed to be updated much faster.  At least I wasn't able to reproduce the issue of missing input after the change of this commit.
If it actually still is an issue that sometimes occurs, we can maybe fix it by adding a short sleep before accessing `user_input`.

Resolves #155.  However, we should probably still report the issue to the Reflex devs.

**Do not merge before:**
- #157 