### PR TITLE
fix: Use `submit_time_stamp` to filter results without submission

### DIFF
--- a/aitutor/pages/submissions/state.py
+++ b/aitutor/pages/submissions/state.py
@@ -98,7 +98,7 @@ class SubmissionsState(FilterMixin, SessionState):
 
             # filter with only with submission
             if self.only_with_submission:
-                stmt = stmt.where(ExerciseResult.finished_conversation != [])
+                stmt = stmt.where(ExerciseResult.submit_time_stamp != None)  # noqa: E711
 
             # get submissions from db
             self.table_rows = [


### PR DESCRIPTION
The `!= []` comparison for the JSON-field `finished_conversation` does not work like this with postgresql.
Since we anyway also have the field `submit_time_stap`, which contains the timestamp of the last submission and is NULL if there is no submission, simply use that instead.
That way, the filter should work fine for both Sqlite and Postgresql.

Note that `x != None` is needed instead of `x is not None` for SQLAlchemy (hence ignoring the warning).

Fixes #177 