### PR TITLE
Docker build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,12 @@ RUN mv /tmp/client .web/build/client
 # =======================================
 FROM python:3.13-slim
 
+# Install libpq-dev for psycopg (skip if not using postgres).
+RUN apt-get update -y && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 RUN adduser --disabled-password --home /app reflex
 COPY --chown=reflex --from=init /app /app
-
-# Install libpq-dev for psycopg (skip if not using postgres).
-RUN apt-get update -y && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
 
 USER reflex
 ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1


### PR DESCRIPTION
- [fix: Don't install dev dependencies in docker](https://github.com/georgmartius/ai-tutor/pull/187/commits/5d208b117093c2edb7413a820656861f030609d2): Set UV_NO_DEV, so we don't need to pass the flag to every call. Previously, the dev group was still installed on the `uv run` call.
- [docker: change order of commands to improve cacheability](https://github.com/georgmartius/ai-tutor/pull/187/commits/8885668444f68757d17ac288404e47e9778a0a9d): If I got it right, moving the apt-get command above the COPY, allows docker to reuse the cached layer when rebuilding after a change in the code.  This notably reduces build time while debugging.