### PR TITLE
fix double dialog

### DIFF
--- a/aitutor/pages/manage_exercises/components.py
+++ b/aitutor/pages/manage_exercises/components.py
@@ -183,6 +183,7 @@ def exercise_table():
                 max_height="66vh",
             ),
             edit_exercise_dialog(),
+            add_exercise_dialog(),
         ),
     )
 
@@ -218,15 +219,19 @@ def hide_exercise_button(exercise: Exercise):
 
 def add_exercise_button() -> rx.Component:
     """Button for adding new exercises."""
+    return rx.button(
+        rx.icon("file-plus", size=26),
+        rx.text(LanguageState.add_exercise, size="4"),
+        size="3",
+        _hover={"cursor": "pointer"},
+        on_click=ManageExercisesState.open_add_dialog,
+        type="button",
+    )
+
+
+def add_exercise_dialog() -> rx.Component:
+    """Dialog for adding new exercises."""
     return rx.dialog.root(
-        rx.button(
-            rx.icon("file-plus", size=26),
-            rx.text(LanguageState.add_exercise, size="4"),
-            size="3",
-            _hover={"cursor": "pointer"},
-            on_click=ManageExercisesState.open_add_dialog,
-            type="button",
-        ),
         rx.dialog.content(
             rx.hstack(
                 rx.badge(


### PR DESCRIPTION
resolves #191 

The `add exercise dialog` now opens only once. The error was that the dialog was rendered directly in the `add_exercise_button()` function. But since this function is called twice in the code (once in the desktop and once in the mobile view), the dialog also existed twice and both opened.
I fixed it by extracting the dialog into an extra function so it now only exists once.