### PR TITLE
chore: Add docker build test to GitHub workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: docker compose build
-        run: docker compose build
+        run: COMPOSE_BAKE=true docker compose build

--- a/Caddy.Dockerfile
+++ b/Caddy.Dockerfile
@@ -1,4 +1,4 @@
 FROM library/caddy
 
-COPY --from=local/ai-tutor-app /app/.web/build/client /srv
+COPY --from=app_image /app/.web/build/client /srv
 ADD Caddyfile /etc/caddy/Caddyfile

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ repo](https://github.com/reflex-dev/reflex/tree/main/docker-example/production-c
 
 To test locally, simply run (from the projects root directory)
 ```
-docker compose build
+COMPOSE_BAKE=true docker compose build
 ```
 to build images using the current state of the code and run with
 ```
@@ -155,7 +155,7 @@ To deploy on a server
 - Add `DOMAIN=your-domain.com` to `.env`
 - Build the images
   ```
-  docker compose build
+  COMPOSE_BAKE=true docker compose build
   ```
 - Run in production mode:
   ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,6 @@
 # to publicly accessible domain where app will be hosted
 services:
   app:
-    image: local/ai-tutor-app
     environment:
       DB_URL: sqlite:///data/reflex.db
     build:
@@ -33,6 +32,8 @@ services:
     build:
       context: .
       dockerfile: Caddy.Dockerfile
+      additional_contexts:
+        app_image: "service:app"
     volumes:
       - caddy-data:/data/caddy
       - caddy-config:/config/caddy


### PR DESCRIPTION
It happens quite often that a change in the code breaks the docker build (typically by adding a `rx.var` that accesses the database, thus making the `reflex export` step fail).
To avoid this in the future, I'm adding a GitHub workflow that runs `docker compose build` on pull request.