### PR TITLE
fix docker build (db access in LanguageState)

### DIFF
--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -109,7 +109,7 @@ class LanguageState(SessionState):
         """The string for the 'Dashboard' heading."""
         return self.translate(de="Übersicht", en="Dashboard")
 
-    @rx.var
+    @rx.var(initial_value="")
     def welcome_back(self) -> str:
         """Welcome back string"""
         username = self.authenticated_user.username


### PR DESCRIPTION
Set initial_value for `LanguageState.welcome_back` var, which accesses the database for the user's name.
This is needed as otherwise the `reflex export` step in the docker build fails (access to database before database is initialised).