### PR TITLE
Registration code

### DIFF
--- a/aitutor/config.py
+++ b/aitutor/config.py
@@ -39,6 +39,7 @@ class AiTutorConfig:
     lecture_information_text: str
     course_name: str
     impressum_text: str
+    registration_code: str
     default_users: list[ConfigDefaultUser]
     exercise_prompts: list[ConfigExercisePrompt]
 

--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -642,6 +642,19 @@ class LanguageState(SessionState):
             en="Registration successful! You can now log in.",
         )
 
+    @rx.var
+    def registration_code(self) -> str:
+        """Registration Code string"""
+        return self.translate(de="Registrierungscode", en="Registration code")
+
+    @rx.var
+    def registration_code_placeholder(self) -> str:
+        """Registration code placeholder string"""
+        return self.translate(
+            de="Sie bekommen diesen Code von Ihrem Lehrer",
+            en="You get this code from your teacher",
+        )
+
     # Manage Users Page Strings --------------------------------------------------------
     @rx.var
     def manage_users(self) -> str:

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -180,6 +180,14 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.confirm_password,
                 on_change=MyRegisterState.set_confirm_password,
             ),
+            rx.text(LanguageState.registration_code),
+            input(
+                "registration_code",
+                placeholder=LanguageState.registration_code_placeholder,
+                required=True,
+                value=MyRegisterState.registration_code,
+                on_change=MyRegisterState.set_registration_code,
+            ),
             rx.cond(
                 privacy_notice,
                 rx.callout(

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -4,6 +4,7 @@ import reflex as rx
 import reflex_local_auth
 
 from aitutor.models import UserInfo, UserRole
+from aitutor.config import get_config
 
 
 class ShowPasswordMixin(rx.State, mixin=True):
@@ -38,6 +39,7 @@ class MyRegisterState(ShowPasswordMixin, reflex_local_auth.RegistrationState):
     email: str = ""
     password: str = ""
     confirm_password: str = ""
+    registration_code: str = ""
 
     @rx.event
     def set_username(self, value: str):
@@ -60,6 +62,11 @@ class MyRegisterState(ShowPasswordMixin, reflex_local_auth.RegistrationState):
         self.confirm_password = value
 
     @rx.event
+    def set_registration_code(self, value: str):
+        """Set the registration code."""
+        self.registration_code = value
+
+    @rx.event
     def on_load(self):
         """function that gets called when the register page loads"""
         self.clear_state_vars()
@@ -73,6 +80,7 @@ class MyRegisterState(ShowPasswordMixin, reflex_local_auth.RegistrationState):
         self.email = ""
         self.password = ""
         self.confirm_password = ""
+        self.registration_code = ""
 
     # This event handler must be named something besides `handle_registration`!!!
     @rx.event
@@ -86,6 +94,13 @@ class MyRegisterState(ShowPasswordMixin, reflex_local_auth.RegistrationState):
         Returns:
             Any: The result of the registration process.
         """
+        # check for the correct registration code
+        registration_code = get_config().registration_code
+        if form_data["registration_code"] != registration_code:
+            self.error_message = "The registration code is wrong."
+            self.registration_code = ""
+            return
+
         registration_result = self.handle_registration(form_data)
         if self.new_user_id >= 0:
             self.clear_state_vars()

--- a/default_config.toml
+++ b/default_config.toml
@@ -31,6 +31,8 @@ course_name = "Example Lecture XY"
 
 impressum_text = "This is the impressum text."
 
+registration_code = "exampleCode1234"
+
 [[default_users]]
 role = "admin"
 name = "admin"

--- a/docs/configfile.md
+++ b/docs/configfile.md
@@ -67,6 +67,13 @@ It has to contain information for who is responsible for the contents of the web
 impressum_text = "This is the impressum text."
 ```
 
+## Registration Code
+To prevent random people from registering an account and burning the api tokens, you have to define a registration code. New users must type in this code when registering their account.
+```toml
+registration_code = "exampleCode1234"
+```
+
+
 ## default_users
 
 You can define a number of default users, that are automatically created.  This is


### PR DESCRIPTION
resolves #200 

# Changes
<img width="458" height="699" alt="image" src="https://github.com/user-attachments/assets/c8a3c81b-466f-4096-986d-97d5018a7851" />

- new `registration_code` var in the config file
- updated documentation
- registration code must be typed in during registration. Otherwise there will be an error message and the registration won't work.
   - Note: The error message is in plain english since it's not that easy to get the language in the RegisterState. But this is no problem since the other error messages are also in plain english. This is because they are defined in the reflex_local_auth files.