### PR TITLE
restrict username to letters and '._-'

### DIFF
--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -96,8 +96,10 @@ class MyRegisterState(ShowPasswordMixin, reflex_local_auth.RegistrationState):
             Any: The result of the registration process.
         """
         # check for allowed user name
-        if not re.match(r"^[a-zA-Z._-]+$", form_data["username"]):
-            self.error_message = "Username can only contain letters and '. _ -'"
+        if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
+            self.error_message = (
+                "Username can only contain letters, numbers and '. _ -'"
+            )
             self.username = ""
             return
 


### PR DESCRIPTION
resolves #203 

# Changes
- Usernames can now only have the following symbols: `a-zA-Z._-`
- If they have other symbols, the user sees this error message:
   <img width="758" height="87" alt="image" src="https://github.com/user-attachments/assets/f1230af8-e583-4baf-8b6e-abf0db75fffb" />
