### PR TITLE
Add info text about roles in edit user dialog

### DIFF
--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -8,6 +8,8 @@ This class has all strings used in the frontend code. Strings that are used in t
 backend code (e.g. error/success messages) are in the corresponding state class.
 """
 
+import textwrap
+
 import reflex as rx
 
 from aitutor.auth.state import SessionState, Language
@@ -708,6 +710,21 @@ class LanguageState(SessionState):
         return self.translate(
             de="Alle Übungen und Abgaben dieses Benutzers werden ebenfalls gelöscht. Dies kann nicht rückgängig gemacht werden!",
             en="All exercises and submissions of this user will also be deleted.  This cannot be undone!",
+        )
+
+    @rx.var
+    def roles_description(self) -> str:
+        return self.translate(
+            de=textwrap.dedent("""
+                - STUDENT: Kann Übungen ansehen und bearbeiten.
+                - TUTOR: Kann zusätzlich Abgaben aller Nutzer einsehen.
+                - ADMIN: Kann alles (Übungen anlegen, Benutzer verwalten...).
+            """),
+            en=textwrap.dedent("""
+                - STUDENT: Can view and work on exercises.
+                - TUTOR: Can also view submissions by all users.
+                - ADMIN: Can do everything (create exercises, manage users...).
+            """),
         )
 
 

--- a/aitutor/pages/manage_users/components.py
+++ b/aitutor/pages/manage_users/components.py
@@ -149,16 +149,24 @@ def edit_user_dialog() -> rx.Component:
                             state=ManageUsersState,
                         ),
                         form_label(LS.role),
-                        rx.select(
-                            (
-                                UserRole.ADMIN.name,
-                                UserRole.TUTOR.name,
-                                UserRole.STUDENT.name,
+                        rx.hstack(
+                            rx.select(
+                                (
+                                    UserRole.ADMIN.name,
+                                    UserRole.TUTOR.name,
+                                    UserRole.STUDENT.name,
+                                ),
+                                default_value=role_to_text(user_info.role),  # type: ignore
+                                size="3",
+                                name="role",
                             ),
-                            default_value=role_to_text(user_info.role),  # type: ignore
-                            size="3",
-                            width="100%",
-                            name="role",
+                            rx.dialog.root(
+                                rx.dialog.trigger(
+                                    rx.icon("info"), _hover={"cursor": "pointer"}
+                                ),
+                                rx.dialog.content(rx.markdown(LS.roles_description)),
+                            ),
+                            align="center",
                         ),
                         form_label(LS.enabled),
                         rx.checkbox(


### PR DESCRIPTION
Add a little help dialog to the role selection, which describes the permissions each role has:

![2025-10-08 16 23 03 localhost ee65ae985bf5](https://github.com/user-attachments/assets/919e9dc7-dd79-4248-aade-a9749c00d5be)

When clicked, opens this dialog:
![2025-10-08 16 23 14 localhost 353cd4fc505e](https://github.com/user-attachments/assets/f22ba23f-56e5-4684-b5ac-3a1ca9683a1c)
