### PR TITLE
Use href instead of on_click for links

### DIFF
--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -97,7 +97,7 @@ def login_form() -> rx.Component:
             ),
             rx.button(LanguageState.log_in, width="100%", _hover={"cursor": "pointer"}),
             rx.center(
-                rx.link(LanguageState.register, on_click=rx.redirect(routes.REGISTER)),
+                rx.link(LanguageState.register, href=routes.REGISTER),
                 width="100%",
             ),
             min_width=MIN_WIDTH,
@@ -212,10 +212,7 @@ def register_form() -> rx.Component:
                 _hover={"cursor": "pointer"},
             ),
             rx.center(
-                rx.link(
-                    LanguageState.log_in,
-                    on_click=lambda: rx.redirect(routes.LOGIN),
-                ),
+                rx.link(LanguageState.log_in, href=routes.LOGIN),
                 width="100%",
             ),
             min_width=MIN_WIDTH,


### PR DESCRIPTION
The links at the bottom of the login/registration forms (pointing to the other form) were not always working (see #233).
Instead of of an `on_click` event, use `href` to make it a regular link. This works more reliably (at least I could not reproduce the issue anymore) and is probably anyway better practice for ordinary links like this (no need for javascript here).

Fixes #233.