### PR TITLE
export prompt_template & is_hidden

### DIFF
--- a/aitutor/pages/manage_exercises/state.py
+++ b/aitutor/pages/manage_exercises/state.py
@@ -207,7 +207,6 @@ class ManageExercisesState(FilterMixin, SessionState):
                     "description": ex.description,
                     "lesson_context": ex.lesson_context,
                     "prompt_name": ex.prompt_name,
-                    "prompt_template": self.prompts.get(ex.prompt_name, ""),
                     "is_hidden": ex.is_hidden,
                     "deadline": ex.deadline.isoformat() if ex.deadline else None,
                     "days_to_complete": ex.days_to_complete,
@@ -215,7 +214,9 @@ class ManageExercisesState(FilterMixin, SessionState):
                 }
             )
 
-        json_data = json.dumps(exercises_dicts, indent=4)
+        json_data = json.dumps(
+            {"prompt_templates": self.prompts, "exercises": exercises_dicts}, indent=4
+        )
         timestamp = datetime.today().date().isoformat()
 
         return rx.download(


### PR DESCRIPTION
addition to the PR #250 

I now also export the `prompt_template` and the `is_hidden` field.
Even if we maybe don't use these fields when importing exercises now, it makes the json files forward compatible to future import features that may want to use the information (like the `is_hidden` field).
The prompt template will not be used for import as long as we handle the prompts in the config file. But when switching the prompt handling to a page (#130), it will be useful to have the prompt in the json files already.