### PR TITLE
Pin postgres container version

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,7 +2,7 @@
 #     docker compose -f compose.yaml -f compose.prod.yaml up -d
 services:
   db:
-    image: postgres
+    image: postgres@sha256:073e7c8b84e2197f94c8083634640ab37105effe1bc853ca4d5fbece3219b0e8
     restart: always
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
This is the version currently used on the servers.  Pin it for now to avoid any unpleasant surprises while updating.

For the next semester, we should probably rather use a version tag (e.g. `postgres:18`) instead of a specific image but for now, this seems to be the safest route for me.