### PR TITLE
Fix Check Conversation Race Condition

### DIFF
--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 
 import decouple
 import reflex as rx
-from openai import AsyncOpenAI, OpenAI
+from openai import AsyncOpenAI
 from pydantic import BaseModel
 from sqlmodel import select
 


### PR DESCRIPTION
resolves #264 

# Changes
The problem of the spinner not showing sometimes was a result of us not using the `AsyncOpenAI` client.
For the normal `get_chat_response` function we already used the `AsyncOpenAI` client, which is why the spinner always showed when sending a message.
I use the `AsyncApenAI` client now for the check_conversation_response. So this bug is fixed.