### PR TITLE
add short privacy notice to homepage

### DIFF
--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -216,6 +216,14 @@ class LanguageState(SessionState):
         """Datenschutzerklärung string"""
         return self.translate(de="Datenschutzerklärung", en="Privacy Notice")
 
+    @rx.var
+    def privacy_notice_short(self) -> str:
+        """Short Datenschutzerklärung string"""
+        return self.translate(
+            de="Datenschutzerklärung Kurzfassung",
+            en="Privacy Notice Summary",
+        )
+
     # Exercise Page Strings ------------------------------------------------------------
     @rx.var
     def deadline(self) -> str:

--- a/aitutor/pages/home/components.py
+++ b/aitutor/pages/home/components.py
@@ -6,6 +6,7 @@ import aitutor.global_vars as gv
 from aitutor import DisplayConfigState, routes
 from aitutor.language_state import LanguageState
 from aitutor.pages.home.state import HomeState
+from aitutor.pages.legal_infos.loader_functions import get_privacy_notice_short
 from aitutor.routes import LOGIN, REGISTER
 
 
@@ -109,11 +110,13 @@ def dashboard_card():
 
 def info_accordion():
     """Render the info accordion"""
+    privacy_notice_short: str = get_privacy_notice_short()
     return (
         rx.cond(
             (DisplayConfigState.how_to_use_text != "")
             | (DisplayConfigState.general_information_text != "")
-            | (DisplayConfigState.lecture_information_text != ""),
+            | (DisplayConfigState.lecture_information_text != "")
+            | (privacy_notice_short != ""),
             rx.accordion.root(
                 rx.cond(
                     DisplayConfigState.how_to_use_text != "",
@@ -138,6 +141,13 @@ def info_accordion():
                         content=rx.markdown(
                             DisplayConfigState.lecture_information_text
                         ),
+                    ),
+                ),
+                rx.cond(
+                    privacy_notice_short != "",
+                    rx.accordion.item(
+                        header=LanguageState.privacy_notice_short,
+                        content=rx.markdown(privacy_notice_short),
                     ),
                 ),
                 width="100%",


### PR DESCRIPTION
resolves #279 

# Changes
The privacy notice short version is now displayed in the info accordion:
<img width="914" height="315" alt="grafik" src="https://github.com/user-attachments/assets/f01aaa36-aa7f-47ca-99c5-3990470f94d6" />
