### PR TITLE
Align report dialog buttons to right

### DIFF
--- a/aitutor/pages/chat/components.py
+++ b/aitutor/pages/chat/components.py
@@ -352,6 +352,7 @@ def report_conversation_button() -> rx.Component:
                     )
                 ),
                 margin_top="1em",
+                justify="end",
             ),
         ),
     )


### PR DESCRIPTION
# Quick fix
The buttons in this dialog were aligned on the left. Everywhere else on the app they are aligned to the right so I quickly changed that.
It looks like this now:
<img width="638" height="279" alt="grafik" src="https://github.com/user-attachments/assets/3cf8ba05-1be0-4239-bf1a-30f54369f064" />
