### PR TITLE
Always show export & delete button

### DIFF
--- a/aitutor/pages/manage_exercises/components.py
+++ b/aitutor/pages/manage_exercises/components.py
@@ -240,8 +240,13 @@ def delete_selected_exercises_button() -> rx.Component:
                 size="3",
             ),
             color_scheme="red",
-            _hover={"cursor": "pointer"},
+            _hover=rx.cond(
+                ManageExercisesState.something_is_selected,
+                {"cursor": "pointer"},
+                {"cursor": "not-allowed"},
+            ),
             type="button",
+            disabled=~ManageExercisesState.something_is_selected,
         ),
     )
 
@@ -257,9 +262,14 @@ def export_selected_exercises_button() -> rx.Component:
             + ")",
             size="3",
         ),
-        _hover={"cursor": "pointer"},
+        _hover=rx.cond(
+            ManageExercisesState.something_is_selected,
+            {"cursor": "pointer"},
+            {"cursor": "not-allowed"},
+        ),
         on_click=ManageExercisesState.export_selected_exercises,
         type="button",
+        disabled=~ManageExercisesState.something_is_selected,
     )
 
 

--- a/aitutor/pages/manage_exercises/page.py
+++ b/aitutor/pages/manage_exercises/page.py
@@ -26,28 +26,18 @@ def manage_exercises_page() -> rx.Component:
     return rx.center(
         rx.vstack(
             rx.desktop_only(
-                rx.cond(
-                    ManageExercisesState.something_is_selected,
+                rx.hstack(
                     rx.hstack(
-                        rx.hstack(
-                            delete_selected_exercises_button(),
-                            export_selected_exercises_button(),
-                        ),
-                        rx.hstack(
-                            import_exercises_button(),
-                            add_exercise_button(),
-                        ),
-                        align="center",
-                        justify="between",
-                        width="100%",
+                        delete_selected_exercises_button(),
+                        export_selected_exercises_button(),
                     ),
                     rx.hstack(
                         import_exercises_button(),
                         add_exercise_button(),
-                        align="center",
-                        justify="end",
-                        width="100%",
                     ),
+                    align="center",
+                    justify="between",
+                    width="100%",
                 ),
                 width="100%",
             ),
@@ -55,16 +45,13 @@ def manage_exercises_page() -> rx.Component:
                 rx.hstack(
                     import_exercises_button(),
                     add_exercise_button(),
-                )
+                ),
             ),
             rx.mobile_and_tablet(
-                rx.cond(
-                    ManageExercisesState.something_is_selected,
-                    rx.hstack(
-                        delete_selected_exercises_button(),
-                        export_selected_exercises_button(),
-                    ),
-                )
+                rx.hstack(
+                    delete_selected_exercises_button(),
+                    export_selected_exercises_button(),
+                ),
             ),
             search_bar(ManageExercisesState),
             search_badges(ManageExercisesState),


### PR DESCRIPTION
resolves #287 

# Changes
The Export and Delete button is now always visible so that the user knows they exist. They are just disabled when nothing is selected.