### PR TITLE
Always show report button

### DIFF
--- a/aitutor/pages/chat/components.py
+++ b/aitutor/pages/chat/components.py
@@ -363,7 +363,6 @@ def submitted_status() -> rx.Component:
     Render the status when the conversation is submitted.
     """
     return rx.hstack(
-        report_conversation_button(),
         rx.hover_card.root(
             rx.hover_card.trigger(
                 rx.button(
@@ -396,14 +395,9 @@ def not_submitted_status() -> rx.Component:
     Render the status when the conversation is not submitted yet.
     """
     return rx.hstack(
-        report_conversation_button(),
-        rx.hstack(
-            rx.icon("info", size=20),
-            rx.text(LanguageState.not_submitted_yet),
-            spacing="1",
-            align="center",
-        ),
-        spacing="4",
+        rx.icon("info", size=20),
+        rx.text(LanguageState.not_submitted_yet),
+        spacing="1",
         align="center",
     )
 

--- a/aitutor/pages/chat/page.py
+++ b/aitutor/pages/chat/page.py
@@ -6,7 +6,12 @@ import aitutor.routes as routes
 from aitutor.auth.protection import page_require_role_at_least
 from aitutor.language_state import LanguageState
 from aitutor.models import UserRole
-from aitutor.pages.chat.components import chat_form, show_exercise_status, show_messages
+from aitutor.pages.chat.components import (
+    chat_form,
+    report_conversation_button,
+    show_exercise_status,
+    show_messages,
+)
 from aitutor.pages.chat.state import ChatState
 from aitutor.pages.navbar import with_navbar
 
@@ -32,13 +37,25 @@ def chat_page() -> rx.Component:
                         align="center",
                     ),
                     rx.tablet_and_desktop(
-                        show_exercise_status(),
+                        rx.hstack(
+                            report_conversation_button(),
+                            show_exercise_status(),
+                            spacing="4",
+                            align="center",
+                        ),
                     ),
                     align="center",
                     justify="between",
                     width="100%",
                 ),
-                rx.mobile_only(show_exercise_status()),
+                rx.mobile_only(
+                    rx.hstack(
+                        report_conversation_button(),
+                        show_exercise_status(),
+                        spacing="4",
+                        align="center",
+                    ),
+                ),
                 rx.cond(
                     ChatState.is_overdue,
                     rx.callout(


### PR DESCRIPTION
resolves #288 

I moved the report button component outside of the submitted status. This way it is always displayed regardless of the submitted status or if the exercise is overdue.