### PR TITLE
Migration bugfix

### DIFF
--- a/alembic/versions/98ca1037a63e_.py
+++ b/alembic/versions/98ca1037a63e_.py
@@ -22,6 +22,9 @@ def upgrade() -> None:
     """Upgrade schema."""
     bind = op.get_bind()
 
+    if bind.dialect.name == 'sqlite':
+        bind.execute(sa.text("PRAGMA foreign_keys=OFF"))
+
     # minimal table structure for data manipulation
     exercise_table = sa.Table(
         "exercise",


### PR DESCRIPTION
SQLite does not have the alter operation like postgresql. So when running the migration script with sqlite, the exercise table is deleted and created agein. This results in exercise results and exercise tag links beeing deleted.
To fix this, the foreign keys are turned off during migration for sqlite.