### PR TITLE
fix: Fix some weird migration issue

### DIFF
--- a/alembic/versions/13978d7d4420_rename_userrole_teacher_tutor.py
+++ b/alembic/versions/13978d7d4420_rename_userrole_teacher_tutor.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
     bind = op.get_bind()
     if bind.engine.name == 'postgresql':
         # Skip this for SQLite, which doesn't have a custom type for this
-        op.execute("ALTER TYPE userrole ADD VALUE 'TUTOR'")
+        op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'TUTOR'")
         op.execute("COMMIT")
     op.execute("UPDATE userinfo SET role = 'TUTOR' WHERE role = 'TEACHER'")
 


### PR DESCRIPTION
I ran into some error when resolving a setup issue on some new instances.  Not sure what exactly was going on, but adding the IF NOT EXISTS clause here resolved an error.