### PR TITLE
docker: fail if config files are not found

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,8 +15,19 @@ services:
       - db-data:/app/data
       - upload-data:/app/uploaded_files
       # mount config files, so we can change config without rebuilding the container
-      - ./config.toml:/app/config.toml
-      - ./.env:/app/.env
+      - type: bind
+        source: ./config.toml
+        target: /app/config.toml
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ./.env
+        target: /app/.env
+        read_only: true
+        bind:
+          create_host_path: false
+
     restart: always
 
   webserver:


### PR DESCRIPTION
The default behaviour of Docker compose is to automatically create a directory on the host if a specified bind volume does not exist. This can be very annoying when binding config files as a missing file doesn't result in an error but it will simply use the default config instead.  This actually happened when I set up the instances for this semester and it took me quite some time to figure out and fix.

To avoid this in the future, use the more verbose notation and set `create_host_path` to false, resulting in an error if the file is missing.