### PR TITLE
fix: Update permission check decorators for token_analyzer

### DIFF
--- a/aitutor/pages/token_analyzer/page.py
+++ b/aitutor/pages/token_analyzer/page.py
@@ -3,7 +3,7 @@
 import reflex as rx
 
 from aitutor import routes
-from aitutor.auth.protection import page_require_role_at_least
+from aitutor.auth.protection import page_require_role_or_permission
 from aitutor.models import UserRole
 from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_admin import with_admin_navbar
@@ -20,7 +20,7 @@ from aitutor.pages.token_analyzer.state import (
 
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.TOKEN_ANALYZER)
-@page_require_role_at_least(UserRole.ADMIN)
+@page_require_role_or_permission(required_role=UserRole.ADMIN)
 def token_analyzer_page() -> rx.Component:
     """Token analyzer page for user token usage overview."""
     return rx.center(

--- a/aitutor/pages/token_analyzer/state.py
+++ b/aitutor/pages/token_analyzer/state.py
@@ -6,7 +6,7 @@ from math import floor, log10
 import reflex as rx
 from sqlmodel import func, select
 
-from aitutor.auth.protection import state_require_role_at_least
+from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.language_state import BackendTranslations as BT
 from aitutor.models import Exercise, ExerciseResult, LocalUser, UserInfo, UserRole
@@ -100,7 +100,7 @@ class TokenAnalyzerState(SessionState):
         self.user_filter_query = ""
 
     @rx.event
-    @state_require_role_at_least(UserRole.ADMIN)
+    @state_require_role_or_permission(required_role=UserRole.ADMIN)
     def on_load(self):
         """Gets executed when the page loads."""
         self.global_load()


### PR DESCRIPTION
The token analyzer and the change that affected the permission decorators were merged in parallel, so this was not caught by checks or testing of the individual pull requests.

Luckily the pyright check run on main after the merge immediately revealed the issue.  I'll see if I can change the repo settings to avoid this in the future.