### PR TITLE
Increase default token limit to 100k

### DIFF
--- a/aitutor/models.py
+++ b/aitutor/models.py
@@ -229,7 +229,7 @@ class Config(SQLModel, table=True):
     course_name: str
     impressum_text: str
     registration_code: str
-    exercise_token_limit: int = Field(default=30000)
+    exercise_token_limit: int
 
     def __repr__(self):
         return f"<Config(id={self.id}, course_name='{self.course_name}')>"

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -166,7 +166,7 @@ class ChatState(SessionState):
     report_text: str = ""
     MAX_REPORT_LENGTH: int = 2000
     current_tokens: int = 0
-    token_limit: int = 30000
+    token_limit: int = 0
 
     @rx.var
     def token_limit_reached(self) -> bool:

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -18,7 +18,7 @@ empty_config: Config = Config(
     course_name="failed to load!",
     impressum_text="failed to load!",
     registration_code="failed to load!",
-    exercise_token_limit=30000,
+    exercise_token_limit=0,
 )
 
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -13,7 +13,7 @@ registration_code = "<Enter some code which users need to know to register>"
 
 response_ai_model = "gpt-4.1-mini"
 check_ai_model = "gpt-4.1"
-exercise_token_limit = 30000
+exercise_token_limit = 100000
 
 # TODO
 impressum_text = """

--- a/default_config.toml
+++ b/default_config.toml
@@ -13,7 +13,7 @@ registration_code = "<Enter some code which users need to know to register>"
 
 response_ai_model = "gpt-4.1-mini"
 check_ai_model = "gpt-4.1"
-exercise_token_limit = 100000
+exercise_token_limit = 100_000
 
 # TODO
 impressum_text = """

--- a/docs/configfile.md
+++ b/docs/configfile.md
@@ -36,7 +36,7 @@ When the limit is reached:
 - already available actions like submitting a successfully passed exercise remain possible.
 
 ```toml
-exercise_token_limit = 30000
+exercise_token_limit = 100_000
 ```
 
 Choose a value that fits your expected exercise complexity and model cost.


### PR DESCRIPTION
It turned out that the default limit of 30k was a bit too low for actual use cases.  Increase it to 100k.