### PR TITLE
More fine-grained permission checks for displaying navbar links

### DIFF
--- a/aitutor/auth/protection.py
+++ b/aitutor/auth/protection.py
@@ -12,16 +12,24 @@ from aitutor.auth.state import SessionState
 from aitutor.models import GlobalPermission, UserRole
 
 
-def lecture_has_role_at_least(role):
+def lecture_has_role_at_least(role) -> rx.vars.Var[bool]:
+    """Check if the user has the specified role.
+
+    Result is also positive if the user doesn't have the specified role but the global
+    ADMIN permission.
     """
-    Check if the user has the required role to access a specific feature.
-    """
-    user_role = SessionState.user_role
     return (
-        (user_role is not None and user_role >= role)
-        | SessionState.global_permissions.contains(GlobalPermission.ADMIN)
-        | SessionState.global_permissions.contains(GlobalPermission.MAINTAINER)
-    )
+        SessionState.user_role is not None and SessionState.user_role >= role
+    ) | SessionState.global_permissions.contains(GlobalPermission.ADMIN)
+
+
+def has_permission(
+    permission: GlobalPermission,
+) -> rx.vars.Var[bool]:
+    """Check if the user has the specified global permission."""
+    okay = SessionState.global_permissions.contains(GlobalPermission.ADMIN)
+    okay |= SessionState.global_permissions.contains(permission)
+    return okay
 
 
 def page_require_role_or_permission(

--- a/aitutor/pages/home/state.py
+++ b/aitutor/pages/home/state.py
@@ -40,7 +40,7 @@ class HomeState(SessionState):
                 # or the deadline is in the future
                 .where(
                     or_(
-                        Exercise.deadline == None,  # noqa: E711
+                        Exercise.deadline == None,
                         Exercise.deadline > datetime.now(ZoneInfo(TIME_ZONE)),  # type: ignore
                     )
                 )

--- a/aitutor/pages/manage_users/components.py
+++ b/aitutor/pages/manage_users/components.py
@@ -204,7 +204,7 @@ def edit_user_dialog() -> rx.Component:
         )
 
     return rx.cond(
-        ManageUsersState.edited_user != None,  # noqa: E711
+        ManageUsersState.edited_user != None,
         _helper(
             local_user=ManageUsersState.edited_user[0],  # type: ignore
             user_info=ManageUsersState.edited_user[1],  # type: ignore

--- a/aitutor/pages/navbar.py
+++ b/aitutor/pages/navbar.py
@@ -2,16 +2,65 @@
 This module defines the navbar components for the Reflex application.
 """
 
+from dataclasses import dataclass
 from typing import Optional
 
 import reflex as rx
 
 import aitutor.routes as routes
 from aitutor import DisplayConfigState
-from aitutor.auth.protection import lecture_has_role_at_least
+from aitutor.auth.protection import has_permission, lecture_has_role_at_least
 from aitutor.auth.state import SessionState
 from aitutor.language_state import LanguageState
 from aitutor.models import GlobalPermission, UserRole
+
+
+@dataclass
+class NavbarLink:
+    """Represents a navigation link in the navbar.
+
+    Attributes:
+        label: The display text for the link.
+        route: The URL route the link points to.
+        icon: The name of the icon to display alongside the link.
+    """
+
+    label: rx.vars.StringVar[str] | str
+    route: str
+    icon: str
+
+
+def get_links():
+    """Returns the list of navigation links for the current user.
+
+    Which links are included depends on the user's permissions.
+
+    Returns:
+        list[tuple[str, str, str]]: A list of tuples each representing one link.  Tuple
+            items are (label, route, icon).
+    """
+    return [
+        NavbarLink(LanguageState.home_link, routes.HOME, "house"),
+        NavbarLink(LanguageState.exercises_link, routes.EXERCISES, "book"),
+        NavbarLink(LanguageState.lectures_link, routes.MY_LECTURES, "graduation-cap"),
+        rx.cond(
+            lecture_has_role_at_least(UserRole.TUTOR),
+            NavbarLink(
+                LanguageState.submissions_link, routes.SUBMISSIONS, "search-check"
+            ),
+            None,
+        ),
+        rx.cond(
+            lecture_has_role_at_least(UserRole.ADMIN)
+            | has_permission(GlobalPermission.MAINTAINER),
+            NavbarLink(
+                LanguageState.admin_settings_link,
+                routes.MANAGE_EXERCISES,
+                "shield-check",
+            ),
+            None,
+        ),
+    ]
 
 
 def is_highlighted(route_to_highlight: Optional[str], url: str) -> rx.Var[bool]:
@@ -29,63 +78,65 @@ def is_highlighted(route_to_highlight: Optional[str], url: str) -> rx.Var[bool]:
     )
 
 
-def navbar_link(text: str, url: str, route_to_highlight: Optional[str]) -> rx.Component:
-    """
-    Creates a navigation link component.
+def navbar_link_desktop(
+    link: NavbarLink, route_to_highlight: Optional[str]
+) -> rx.Component:
+    """Creates a navigation link component for the desktop menu.
+
+    Args:
+        link: Information about the link to create.
+        route_to_highlight:  The route that should be highlighted as selected.
     """
     return rx.cond(
-        is_highlighted(route_to_highlight, url),
+        is_highlighted(route_to_highlight, link.route),
         rx.link(
             rx.button(
-                rx.text(text, size="4", weight="medium"), _hover={"cursor": "pointer"}
+                rx.text(link.label, size="4", weight="medium"),
+                _hover={"cursor": "pointer"},
             ),
-            href=url,
+            href=link.route,
         ),
         rx.link(
-            rx.text(text, size="4", weight="medium"),
-            href=url,
+            rx.text(link.label, size="4", weight="medium"),
+            href=link.route,
         ),
     )
 
 
-# (label, route, icon)
-general_links = [
-    (LanguageState.home_link, routes.HOME, "house"),
-    (LanguageState.exercises_link, routes.EXERCISES, "book"),
-    (LanguageState.lectures_link, routes.MY_LECTURES, "graduation-cap"),
-]
-tutor_links = [
-    (LanguageState.submissions_link, routes.SUBMISSIONS, "search-check"),
-]
-admin_links = [
-    # navigate to any admin settings page to show the admin settings navbar
-    (LanguageState.admin_settings_link, routes.MANAGE_EXERCISES, "shield-check"),
-]
+def navbar_link_mobile(link: NavbarLink, route_to_highlight: Optional[str]):
+    """Creates a navigation link component for the mobile menu.
 
-
-def get_links():
-    """Returns the list of navigation links for the current user role."""
-    return rx.cond(
-        SessionState.global_permissions.contains(GlobalPermission.ADMIN)
-        | SessionState.global_permissions.contains(GlobalPermission.LECTURER),
+    Args:
+        link: Information about the link to create.
+        route_to_highlight:  The route that should be highlighted as selected.
+    """
+    return rx.menu.item(
         rx.cond(
-            lecture_has_role_at_least(UserRole.ADMIN),
-            general_links + tutor_links + admin_links,
-            rx.cond(
-                lecture_has_role_at_least(UserRole.TUTOR),
-                general_links + tutor_links,
-                general_links,
+            # check if the link should be highlighted
+            is_highlighted(route_to_highlight, link.route),
+            rx.hstack(
+                # highlighted link
+                rx.icon(
+                    link.icon,
+                    size=15,
+                    color=rx.color("accent", 9),
+                ),
+                rx.text(
+                    link.label,
+                    weight="bold",
+                    color=rx.color("accent", 9),
+                ),
+                align="center",
+            ),
+            rx.hstack(
+                # non-highlighted link
+                rx.icon(link.icon, size=15),
+                rx.text(link.label),
+                align="center",
             ),
         ),
-        rx.cond(
-            lecture_has_role_at_least(UserRole.ADMIN),
-            general_links + tutor_links + admin_links,
-            rx.cond(
-                lecture_has_role_at_least(UserRole.TUTOR),
-                general_links + tutor_links,
-                general_links,
-            ),
-        ),
+        on_click=rx.redirect(link.route),
+        _hover={"cursor": "pointer"},
     )
 
 
@@ -234,7 +285,6 @@ def navbar(route_to_highlight: Optional[str]) -> rx.Component:
     Returns:
         rx.Component: A Reflex box component containing the navigation bar.
     """
-    links = get_links()
     return rx.box(
         rx.desktop_only(
             rx.hstack(
@@ -254,9 +304,10 @@ def navbar(route_to_highlight: Optional[str]) -> rx.Component:
                     rx.text(DisplayConfigState.course_name, weight="bold"),
                     rx.hstack(
                         rx.foreach(
-                            links,
-                            lambda link: navbar_link(
-                                link[0], link[1], route_to_highlight
+                            get_links(),
+                            lambda link: rx.cond(
+                                link != None,
+                                navbar_link_desktop(link, route_to_highlight),
                             ),
                         ),
                         spacing="5",
@@ -305,34 +356,10 @@ def navbar(route_to_highlight: Optional[str]) -> rx.Component:
                             ),
                             rx.separator(),
                             rx.foreach(
-                                links,
-                                lambda link: rx.menu.item(
-                                    rx.cond(
-                                        # check if the link should be highlighted
-                                        is_highlighted(route_to_highlight, link[1]),
-                                        rx.hstack(
-                                            # highlighted link
-                                            rx.icon(
-                                                link[2],
-                                                size=15,
-                                                color=rx.color("accent", 9),
-                                            ),
-                                            rx.text(
-                                                link[0],
-                                                weight="bold",
-                                                color=rx.color("accent", 9),
-                                            ),
-                                            align="center",
-                                        ),
-                                        rx.hstack(
-                                            # non-highlighted link
-                                            rx.icon(link[2], size=15),
-                                            rx.text(link[0]),
-                                            align="center",
-                                        ),
-                                    ),
-                                    on_click=rx.redirect(link[1]),
-                                    _hover={"cursor": "pointer"},
+                                get_links(),
+                                lambda link: rx.cond(
+                                    link != None,
+                                    navbar_link_mobile(link, route_to_highlight),
                                 ),
                             ),
                             max_width="90vw",

--- a/aitutor/pages/report_view/page.py
+++ b/aitutor/pages/report_view/page.py
@@ -58,7 +58,7 @@ def report_view_page() -> rx.Component:
                     rx.icon("book", size=18),
                     rx.text(LanguageState.exercise + ":", weight="bold"),
                     rx.cond(
-                        ReportViewState.exercise_title == None,  # noqa: E711
+                        ReportViewState.exercise_title == None,
                         rx.text(LanguageState.deleted_report_title, color="red"),
                         rx.text(ReportViewState.exercise_title),
                     ),

--- a/aitutor/pages/reports/components.py
+++ b/aitutor/pages/reports/components.py
@@ -36,7 +36,7 @@ def show_table_row(table_row: TableRow) -> rx.Component:
         ),
         rx.table.cell(
             rx.cond(
-                table_row.exercise_title == None,  # noqa: E711
+                table_row.exercise_title == None,
                 rx.text(LanguageState.deleted_report_title, color="red"),
                 rx.text(
                     table_row.exercise_title,

--- a/aitutor/pages/submissions/state.py
+++ b/aitutor/pages/submissions/state.py
@@ -82,7 +82,7 @@ class SubmissionsState(FilterMixin, SessionState):
             # filter only rows that are either submitted or hit token limit
             stmt = stmt.where(
                 or_(
-                    ExerciseResult.submit_time_stamp != None,  # noqa: E711
+                    ExerciseResult.submit_time_stamp != None,
                     ExerciseResult.tokens_used >= token_limit,
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ lint.select = [
     "D100", "D101", "D102", "D103",  # Complain about missing docstrings
     "I",
 ]
+lint.ignore = [
+    "E711",  # in rx.cond, we often need to compare None with `==`/`!=`
+]
 extend-exclude = ["alembic"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
I noticed that for users with the "maintainer" permission (but who are not admin or tutor), the submissions page is linked in the navbar, even though the user does not have permission to access it.  So I refactored the logic that checks which links to show, to fix that and hopefully make it a bit more flexible.

- Do not group links but have a separate permission check for each of  them.  This adds some overhead but makes it more flexible.  Also replace the tuple with a dataclass to make the code easier to  understand.
- Add function `has_permission` to more easily check if a user has a  specific permission.
- Remove the check for the MAINTAINER permission from  `lecture_has_role_at_least`.  Use the new `has_permission` function  for maintainer pages.
- Globally ignore the E711 rule (use `==`/`!=` for None) as we often need this for both `rx.cond` and SQLAlchemy.