### PR TITLE
style(ui): refresh app layout

### DIFF
--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -17,10 +17,11 @@ from aitutor.utilities.create_default_users import create_default_users
 
 app = rx.App(
     theme=rx.theme(
-        accent_color="indigo",
+        accent_color="blue",
         gray_color="slate",
         radius="medium",
-    )
+    ),
+    stylesheets=["/styles.css"],
 )
 # info: add dynamic routes first
 app.add_page(

--- a/aitutor/pages/all_lectures/page.py
+++ b/aitutor/pages/all_lectures/page.py
@@ -17,7 +17,5 @@ def all_lectures_page() -> rx.Component:
     """Show the page scaffold for all available lectures."""
     return rx.center(
         all_lectures_content(),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/configuration/page.py
+++ b/aitutor/pages/configuration/page.py
@@ -17,7 +17,5 @@ def configuration_page() -> rx.Component:
     """Configuration page."""
     return rx.center(
         config_form(),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/edit_lecture/page.py
+++ b/aitutor/pages/edit_lecture/page.py
@@ -17,7 +17,5 @@ def edit_lecture_page() -> rx.Component:
     """Lecture edit/create page."""
     return rx.center(
         edit_lecture_form(),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/exercises/page.py
+++ b/aitutor/pages/exercises/page.py
@@ -17,42 +17,47 @@ def exercises_page() -> rx.Component:
     """Default wrapper for exercises page"""
     return rx.center(
         rx.vstack(
-            rx.hstack(
-                rx.icon(tag="clock"),
-                rx.moment(
-                    format="HH:mm:ss",
-                    interval=1000,
-                    on_change=ExercisesState.update_time_left_strings,
-                ),
-            ),
-            rx.vstack(
-                search_bar(ExercisesState),
-                rx.cond(
-                    ExercisesState.search_values.length() > 0,  # type: ignore
-                    search_badges(ExercisesState),
-                ),
-                rx.desktop_only(
+            rx.box(
+                rx.vstack(
                     rx.hstack(
-                        filter_options(),
-                        spacing="9",
-                    ),
-                ),
-                rx.mobile_and_tablet(
-                    rx.vstack(
-                        filter_options(),
+                        rx.icon(tag="clock"),
+                        rx.moment(
+                            format="HH:mm:ss",
+                            interval=1000,
+                            on_change=ExercisesState.update_time_left_strings,
+                        ),
                         align="center",
+                        justify="center",
                     ),
+                    search_bar(ExercisesState),
+                    rx.cond(
+                        ExercisesState.search_values.length() > 0,  # type: ignore
+                        search_badges(ExercisesState),
+                    ),
+                    rx.desktop_only(
+                        rx.hstack(
+                            filter_options(),
+                            spacing="9",
+                        ),
+                    ),
+                    rx.mobile_and_tablet(
+                        rx.vstack(
+                            filter_options(),
+                            align="center",
+                        ),
+                    ),
+                    align="center",
+                    justify="center",
+                    spacing="3",
                 ),
-                align="center",
-                justify="center",
+                class_name="app-panel",
+                width="100%",
             ),
             render_exercises(),
             spacing="5",
-            justify="center",
+            justify="start",
             align="center",
             width="100%",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="90%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/home/components.py
+++ b/aitutor/pages/home/components.py
@@ -3,7 +3,7 @@
 import reflex as rx
 
 import aitutor.global_vars as gv
-from aitutor import DisplayConfigState, routes
+from aitutor import DisplayConfigState
 from aitutor.language_state import LanguageState
 from aitutor.pages.home.state import HomeState
 from aitutor.pages.legal_infos.loader_functions import get_privacy_notice_short
@@ -154,19 +154,5 @@ def info_accordion():
                 collapsible=True,
                 variant="outline",
             ),
-        ),
-    )
-
-
-def legal_info_links():
-    """Render the links for Impressum and privacy notice"""
-    return rx.hstack(
-        rx.link(
-            LanguageState.impressum,
-            href=routes.IMPRESSUM,
-        ),
-        rx.link(
-            LanguageState.privacy_notice,
-            href=routes.PRIVACY_NOTICE,
         ),
     )

--- a/aitutor/pages/home/page.py
+++ b/aitutor/pages/home/page.py
@@ -6,7 +6,6 @@ from aitutor import routes
 from aitutor.pages.home.components import (
     dashboard_card,
     info_accordion,
-    legal_info_links,
 )
 from aitutor.pages.navbar import with_navbar
 
@@ -20,12 +19,9 @@ def home_page() -> rx.Component:
             # Dashboard Card
             dashboard_card(),
             info_accordion(),
-            legal_info_links(),
             width="100%",
             align="center",
             justify="center",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="90%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/legal_infos/page.py
+++ b/aitutor/pages/legal_infos/page.py
@@ -20,8 +20,7 @@ def impressum_page() -> rx.Component:
             ),
             align="center",
         ),
-        margin_top="2em",
-        width="90%",
+        class_name="page-frame",
     )
 
 
@@ -37,6 +36,5 @@ def privacy_notice_page() -> rx.Component:
             ),
             align="center",
         ),
-        margin_top="2em",
-        width="90%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/login_and_registration/page.py
+++ b/aitutor/pages/login_and_registration/page.py
@@ -21,9 +21,7 @@ def custom_login_page() -> rx.Component:
             LoginState.is_hydrated,
             rx.card(login_form()),
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="90%",
+        class_name="page-frame",
     )
 
 
@@ -38,7 +36,5 @@ def custom_register_page() -> rx.Component:
             RegistrationState.is_hydrated,
             rx.card(register_form()),
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="90%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/manage_exercises/page.py
+++ b/aitutor/pages/manage_exercises/page.py
@@ -19,6 +19,37 @@ from aitutor.pages.navbar_admin import with_admin_navbar
 from aitutor.utilities.filtering_components import search_badges, search_bar
 
 
+def exercise_toolbar() -> rx.Component:
+    """Render grouped actions for managing exercises."""
+    return rx.box(
+        rx.vstack(
+            rx.hstack(
+                rx.hstack(
+                    import_exercises_button(),
+                    add_exercise_button(),
+                    edit_tags_button(),
+                    class_name="exercise-toolbar-group",
+                ),
+                rx.hstack(
+                    delete_selected_exercises_button(),
+                    export_selected_exercises_button(),
+                    class_name="exercise-toolbar-group",
+                ),
+                class_name="exercise-toolbar-row",
+                width="100%",
+            ),
+            rx.hstack(
+                search_bar(ManageExercisesState),
+                class_name="exercise-search-row",
+                width="100%",
+            ),
+            spacing="3",
+            width="100%",
+        ),
+        class_name="exercise-toolbar",
+    )
+
+
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.MANAGE_EXERCISES)
 @page_require_role_or_permission(required_role=UserRole.ADMIN)
@@ -26,58 +57,13 @@ def manage_exercises_page() -> rx.Component:
     """Manage exercises page."""
     return rx.center(
         rx.vstack(
-            rx.desktop_only(
-                rx.hstack(
-                    rx.hstack(
-                        delete_selected_exercises_button(),
-                        export_selected_exercises_button(),
-                    ),
-                    rx.hstack(
-                        import_exercises_button(),
-                        add_exercise_button(),
-                    ),
-                    align="center",
-                    justify="between",
-                    width="100%",
-                ),
-                width="100%",
-            ),
-            rx.mobile_and_tablet(
-                rx.hstack(
-                    import_exercises_button(),
-                    add_exercise_button(),
-                ),
-            ),
-            rx.mobile_and_tablet(
-                rx.hstack(
-                    delete_selected_exercises_button(),
-                    export_selected_exercises_button(),
-                ),
-            ),
-            rx.mobile_and_tablet(
-                edit_tags_button(),
-            ),
-            rx.mobile_and_tablet(
-                search_bar(ManageExercisesState),
-            ),
-            rx.desktop_only(
-                rx.hstack(
-                    search_bar(ManageExercisesState),
-                    edit_tags_button(),
-                    align="center",
-                    justify="between",
-                    width="100%",
-                ),
-                width="100%",
-            ),
+            exercise_toolbar(),
             search_badges(ManageExercisesState),
             exercise_table(),
             spacing="3",
             align="center",
-            justify="center",
+            justify="start",
             width="100%",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/manage_users/page.py
+++ b/aitutor/pages/manage_users/page.py
@@ -26,7 +26,5 @@ def manage_users_page() -> rx.Component:
             align="center",
             justify="center",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/my_lectures/page.py
+++ b/aitutor/pages/my_lectures/page.py
@@ -17,7 +17,5 @@ def my_lectures_page() -> rx.Component:
     """Show the lectures visible to the current user."""
     return rx.center(
         my_lectures_content(),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/navbar.py
+++ b/aitutor/pages/navbar.py
@@ -1,277 +1,18 @@
-"""
-This module defines the navbar components for the Reflex application.
-"""
+"""Main navbar and app shell layout."""
 
-from dataclasses import dataclass
 from typing import Optional
 
 import reflex as rx
 
 import aitutor.routes as routes
 from aitutor import DisplayConfigState
-from aitutor.auth.protection import has_permission, lecture_has_role_at_least
-from aitutor.auth.state import SessionState
 from aitutor.language_state import LanguageState
-from aitutor.models import GlobalPermission, UserRole
-
-
-@dataclass
-class NavbarLink:
-    """Represents a navigation link in the navbar.
-
-    Attributes:
-        label: The display text for the link.
-        route: The URL route the link points to.
-        icon: The name of the icon to display alongside the link.
-    """
-
-    label: rx.vars.StringVar[str] | str
-    route: str
-    icon: str
-
-
-def get_links():
-    """Returns the list of navigation links for the current user.
-
-    Which links are included depends on the user's permissions.
-
-    Returns:
-        list[tuple[str, str, str]]: A list of tuples each representing one link.  Tuple
-            items are (label, route, icon).
-    """
-    return [
-        NavbarLink(LanguageState.home_link, routes.HOME, "house"),
-        NavbarLink(LanguageState.exercises_link, routes.EXERCISES, "book"),
-        NavbarLink(LanguageState.lectures_link, routes.MY_LECTURES, "graduation-cap"),
-        rx.cond(
-            lecture_has_role_at_least(UserRole.TUTOR),
-            NavbarLink(
-                LanguageState.submissions_link, routes.SUBMISSIONS, "search-check"
-            ),
-            None,
-        ),
-        rx.cond(
-            lecture_has_role_at_least(UserRole.ADMIN)
-            | has_permission(GlobalPermission.MAINTAINER),
-            NavbarLink(
-                LanguageState.admin_settings_link,
-                routes.MANAGE_EXERCISES,
-                "shield-check",
-            ),
-            None,
-        ),
-    ]
-
-
-def is_highlighted(route_to_highlight: Optional[str], url: str) -> rx.Var[bool]:
-    """
-    Determines if a navigation link should be highlighted based on the current route.
-    """
-    return rx.cond(
-        route_to_highlight,  # None check
-        rx.cond(
-            route_to_highlight == routes.HOME,
-            url == routes.HOME,
-            url.startswith(route_to_highlight or ""),  # None handled by outer cond
-        ),
-        False,
-    )
-
-
-def navbar_link_desktop(
-    link: NavbarLink, route_to_highlight: Optional[str]
-) -> rx.Component:
-    """Creates a navigation link component for the desktop menu.
-
-    Args:
-        link: Information about the link to create.
-        route_to_highlight:  The route that should be highlighted as selected.
-    """
-    return rx.cond(
-        is_highlighted(route_to_highlight, link.route),
-        rx.link(
-            rx.button(
-                rx.text(link.label, size="4", weight="medium"),
-                _hover={"cursor": "pointer"},
-            ),
-            href=link.route,
-        ),
-        rx.link(
-            rx.text(link.label, size="4", weight="medium"),
-            href=link.route,
-        ),
-    )
-
-
-def navbar_link_mobile(link: NavbarLink, route_to_highlight: Optional[str]):
-    """Creates a navigation link component for the mobile menu.
-
-    Args:
-        link: Information about the link to create.
-        route_to_highlight:  The route that should be highlighted as selected.
-    """
-    return rx.menu.item(
-        rx.cond(
-            # check if the link should be highlighted
-            is_highlighted(route_to_highlight, link.route),
-            rx.hstack(
-                # highlighted link
-                rx.icon(
-                    link.icon,
-                    size=15,
-                    color=rx.color("accent", 9),
-                ),
-                rx.text(
-                    link.label,
-                    weight="bold",
-                    color=rx.color("accent", 9),
-                ),
-                align="center",
-            ),
-            rx.hstack(
-                # non-highlighted link
-                rx.icon(link.icon, size=15),
-                rx.text(link.label),
-                align="center",
-            ),
-        ),
-        on_click=rx.redirect(link.route),
-        _hover={"cursor": "pointer"},
-    )
-
-
-def get_user_icon():
-    """
-    Determines the appropriate user icon based on the user's authentication and role.
-
-    Returns:
-        rx.Component: A Reflex conditional component representing the user icon.
-    """
-    userrole = SessionState.user_role
-    return rx.cond(
-        ~SessionState.is_authenticated,
-        "user-round",
-        rx.cond(
-            userrole == UserRole.STUDENT,
-            "user-round-check",
-            rx.cond(
-                userrole == UserRole.ADMIN,
-                "user-round-cog",
-                rx.cond(
-                    userrole == UserRole.TUTOR,
-                    "user-round-search",
-                    "user-round",
-                ),
-            ),
-        ),
-    )
-
-
-def get_user_icon_color():
-    """
-    Determines the appropriate color for the user icon based on
-    the user's authentication and role.
-
-    Returns:
-        str: The color for the user icon.
-    """
-    return rx.cond(
-        SessionState.is_authenticated,
-        "accent",
-        "gray",
-    )
-
-
-def profile_menu() -> rx.Component:
-    """
-    Creates a profile menu component for the navigation bar.
-
-    Returns:
-        rx.Component: A Reflex menu component with login/registration/logout options.
-    """
-
-    def menu_item(
-        label: str | rx.vars.StringVar[str], icon: str, on_click
-    ) -> rx.Component:
-        return rx.menu.item(
-            rx.hstack(
-                rx.icon(icon, size=15),
-                rx.text(
-                    label,
-                    size="2",
-                    margin_bottom="6px",
-                    margin_top="6px",
-                ),
-                align="center",
-                justify="center",
-                spacing="1",
-            ),
-            on_click=on_click,
-            _hover={"cursor": "pointer"},
-        )
-
-    return rx.menu.root(
-        rx.menu.trigger(
-            rx.icon_button(
-                rx.icon(get_user_icon()),
-                size="2",
-                radius="full",
-                _hover={"cursor": "pointer"},
-                background_color=get_user_icon_color(),
-            ),
-        ),
-        rx.cond(
-            SessionState.is_authenticated,
-            rx.menu.content(
-                rx.hstack(
-                    rx.icon("circle-user-round", size=15),
-                    rx.text(
-                        {SessionState.authenticated_user.username},
-                        size="2",
-                        margin_bottom="6px",
-                        margin_top="6px",
-                    ),
-                    align="center",
-                    justify="center",
-                    spacing="1",
-                ),
-                rx.separator(),
-                menu_item(
-                    LanguageState.language_string,
-                    icon="languages",
-                    on_click=SessionState.toggle_language,
-                ),
-                menu_item(
-                    LanguageState.user_settings,
-                    icon="cog",
-                    on_click=rx.redirect(routes.USER_SETTINGS),
-                ),
-                menu_item(
-                    LanguageState.log_out,
-                    icon="log-out",
-                    on_click=SessionState.perform_logout,
-                ),
-            ),
-            rx.menu.content(
-                menu_item(
-                    LanguageState.language_string,
-                    icon="languages",
-                    on_click=SessionState.toggle_language,
-                ),
-                menu_item(
-                    LanguageState.log_in,
-                    icon="log-in",
-                    on_click=lambda: rx.redirect(routes.LOGIN),
-                ),
-                menu_item(
-                    LanguageState.register,
-                    icon="notepad-text",
-                    on_click=lambda: rx.redirect(routes.REGISTER),
-                ),
-            ),
-        ),
-        justify="end",
-    )
+from aitutor.pages.navbar_links import (
+    get_links,
+    navbar_link_desktop,
+    navbar_link_mobile,
+)
+from aitutor.pages.navbar_profile import profile_menu, profile_menu_actions
 
 
 def navbar(route_to_highlight: Optional[str]) -> rx.Component:
@@ -338,43 +79,60 @@ def navbar(route_to_highlight: Optional[str]) -> rx.Component:
                     rx.heading("AI Tutor", size="6", weight="bold"),
                     align_items="center",
                 ),
-                rx.hstack(
-                    rx.color_mode.button(),
-                    rx.menu.root(
-                        rx.menu.trigger(
-                            rx.icon("menu", size=30),
-                            _hover={"cursor": "pointer"},
-                        ),
-                        rx.menu.content(
-                            rx.box(
-                                rx.text(
-                                    DisplayConfigState.course_name,
-                                    color_scheme="gray",
-                                    weight="bold",
-                                ),
-                                padding="0.5em",
-                            ),
-                            rx.separator(),
-                            rx.foreach(
-                                get_links(),
-                                lambda link: rx.cond(
-                                    link != None,
-                                    navbar_link_mobile(link, route_to_highlight),
-                                ),
-                            ),
-                            max_width="90vw",
+                rx.menu.root(
+                    rx.menu.trigger(
+                        rx.icon_button(
+                            rx.icon("menu", size=22),
+                            variant="soft",
+                            radius="full",
+                            class_name="mobile-menu-trigger",
                         ),
                     ),
-                    profile_menu(),
+                    rx.menu.content(
+                        rx.box(
+                            rx.text(
+                                DisplayConfigState.course_name,
+                                color_scheme="gray",
+                                weight="bold",
+                            ),
+                            padding="0.5em",
+                        ),
+                        rx.separator(),
+                        rx.foreach(
+                            get_links(),
+                            lambda link: rx.cond(
+                                link != None,
+                                navbar_link_mobile(link, route_to_highlight),
+                            ),
+                        ),
+                        rx.separator(),
+                        profile_menu_actions(),
+                        min_width="14rem",
+                        max_width="90vw",
+                    ),
                 ),
                 justify="between",
                 align_items="center",
                 width="100%",
             ),
         ),
-        bg=rx.color("accent", 3),
+        class_name="site-navbar",
         padding="1em",
         width="100%",
+    )
+
+
+def site_footer() -> rx.Component:
+    """Render legal links at the bottom of the app shell."""
+    return rx.hstack(
+        rx.mobile_and_tablet(rx.color_mode.button()),
+        rx.link(LanguageState.impressum, href=routes.IMPRESSUM),
+        rx.link(LanguageState.privacy_notice, href=routes.PRIVACY_NOTICE),
+        justify="center",
+        align="center",
+        spacing="5",
+        padding="1rem",
+        class_name="site-footer",
     )
 
 
@@ -401,12 +159,18 @@ def with_navbar(route_to_highlight: Optional[str] = None):
             rx.app.ComponentCallable:
             A callable that returns a Reflex component with the navigation bar.
         """
-        return lambda: rx.vstack(
+        return lambda: rx.flex(
             navbar(route_to_highlight),
-            component_factory(),
+            rx.box(
+                component_factory(),
+                class_name="app-main",
+            ),
+            site_footer(),
+            direction="column",
             spacing="0",
             padding="0",
             align="center",
+            class_name="app-shell",
         )
 
     return decorator

--- a/aitutor/pages/navbar_admin.py
+++ b/aitutor/pages/navbar_admin.py
@@ -62,11 +62,12 @@ def admin_navbar(tab_to_highlight: str) -> rx.Component:
                     ),
                 ),
                 width="100%",
+                class_name="subnav-tabs-list",
             ),
             default_value=tab_to_highlight,
             width="100%",
         ),
-        margin_top="0.5em",
+        class_name="subnav-tabs-shell",
         width="100%",
     )
 
@@ -100,7 +101,7 @@ def with_admin_navbar(tab_to_highlight: str):
             spacing="0",
             padding="0",
             align="center",
-            width="90%",
+            width="100%",
         )
 
     return decorator

--- a/aitutor/pages/navbar_lectures.py
+++ b/aitutor/pages/navbar_lectures.py
@@ -47,11 +47,12 @@ def lectures_navbar(tab_to_highlight: str) -> rx.Component:
                     ),
                 ),
                 width="100%",
+                class_name="subnav-tabs-list",
             ),
             default_value=tab_to_highlight,
             width="100%",
         ),
-        margin_top="0.5em",
+        class_name="subnav-tabs-shell",
         width="100%",
     )
 

--- a/aitutor/pages/navbar_links.py
+++ b/aitutor/pages/navbar_links.py
@@ -1,0 +1,108 @@
+"""Navigation link helpers for the main navbar."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import reflex as rx
+
+import aitutor.routes as routes
+from aitutor.auth.protection import has_permission, lecture_has_role_at_least
+from aitutor.language_state import LanguageState
+from aitutor.models import GlobalPermission, UserRole
+
+
+@dataclass
+class NavbarLink:
+    """Represents a navigation link in the navbar."""
+
+    label: rx.vars.StringVar[str] | str
+    route: str
+    icon: str
+
+
+def get_links():
+    """Return the list of navigation links for the current user."""
+    return [
+        NavbarLink(LanguageState.home_link, routes.HOME, "house"),
+        NavbarLink(LanguageState.exercises_link, routes.EXERCISES, "book"),
+        NavbarLink(LanguageState.lectures_link, routes.MY_LECTURES, "graduation-cap"),
+        rx.cond(
+            lecture_has_role_at_least(UserRole.TUTOR),
+            NavbarLink(
+                LanguageState.submissions_link, routes.SUBMISSIONS, "search-check"
+            ),
+            None,
+        ),
+        rx.cond(
+            lecture_has_role_at_least(UserRole.ADMIN)
+            | has_permission(GlobalPermission.MAINTAINER),
+            NavbarLink(
+                LanguageState.admin_settings_link,
+                routes.MANAGE_EXERCISES,
+                "shield-check",
+            ),
+            None,
+        ),
+    ]
+
+
+def is_highlighted(route_to_highlight: Optional[str], url: str) -> rx.Var[bool]:
+    """Return whether a navigation link should be highlighted."""
+    return rx.cond(
+        route_to_highlight,
+        rx.cond(
+            route_to_highlight == routes.HOME,
+            url == routes.HOME,
+            url.startswith(route_to_highlight or ""),
+        ),
+        False,
+    )
+
+
+def navbar_link_desktop(
+    link: NavbarLink, route_to_highlight: Optional[str]
+) -> rx.Component:
+    """Create a navigation link component for the desktop menu."""
+    return rx.cond(
+        is_highlighted(route_to_highlight, link.route),
+        rx.link(
+            rx.button(
+                rx.text(link.label, size="4", weight="medium"),
+                _hover={"cursor": "pointer"},
+            ),
+            href=link.route,
+        ),
+        rx.link(
+            rx.text(link.label, size="4", weight="medium"),
+            href=link.route,
+        ),
+    )
+
+
+def navbar_link_mobile(link: NavbarLink, route_to_highlight: Optional[str]):
+    """Create a navigation link component for the mobile menu."""
+    return rx.menu.item(
+        rx.cond(
+            is_highlighted(route_to_highlight, link.route),
+            rx.hstack(
+                rx.icon(
+                    link.icon,
+                    size=15,
+                    color=rx.color("accent", 9),
+                ),
+                rx.text(
+                    link.label,
+                    weight="bold",
+                    color=rx.color("accent", 9),
+                ),
+                align="center",
+            ),
+            rx.hstack(
+                rx.icon(link.icon, size=15),
+                rx.text(link.label),
+                align="center",
+            ),
+        ),
+        on_click=rx.redirect(link.route),
+        _hover={"cursor": "pointer"},
+    )

--- a/aitutor/pages/navbar_profile.py
+++ b/aitutor/pages/navbar_profile.py
@@ -1,0 +1,141 @@
+"""Profile menu helpers for the main navbar."""
+
+import reflex as rx
+
+import aitutor.routes as routes
+from aitutor.auth.state import SessionState
+from aitutor.language_state import LanguageState
+from aitutor.models import UserRole
+
+
+def get_user_icon():
+    """Return the profile icon that matches authentication and role state."""
+    userrole = SessionState.user_role
+    return rx.cond(
+        ~SessionState.is_authenticated,
+        "user-round",
+        rx.cond(
+            userrole == UserRole.STUDENT,
+            "user-round-check",
+            rx.cond(
+                userrole == UserRole.ADMIN,
+                "user-round-cog",
+                rx.cond(
+                    userrole == UserRole.TUTOR,
+                    "user-round-search",
+                    "user-round",
+                ),
+            ),
+        ),
+    )
+
+
+def get_user_icon_color():
+    """Return the profile icon color for the current authentication state."""
+    return rx.cond(
+        SessionState.is_authenticated,
+        "accent",
+        "gray",
+    )
+
+
+def profile_menu_item(
+    label: str | rx.vars.StringVar[str], icon: str, on_click
+) -> rx.Component:
+    """Create a shared account menu item."""
+    return rx.menu.item(
+        rx.hstack(
+            rx.icon(icon, size=15),
+            rx.text(
+                label,
+                size="2",
+                margin_bottom="6px",
+                margin_top="6px",
+            ),
+            align="center",
+            justify="center",
+            spacing="1",
+        ),
+        on_click=on_click,
+        _hover={"cursor": "pointer"},
+    )
+
+
+def profile_menu_actions() -> rx.Component:
+    """Create account actions for an existing menu content area."""
+    return rx.cond(
+        SessionState.is_authenticated,
+        rx.fragment(
+            rx.hstack(
+                rx.icon("circle-user-round", size=15),
+                rx.text(
+                    {SessionState.authenticated_user.username},
+                    size="2",
+                    margin_bottom="6px",
+                    margin_top="6px",
+                ),
+                align="center",
+                justify="center",
+                spacing="1",
+            ),
+            rx.separator(),
+            profile_menu_item(
+                LanguageState.language_string,
+                icon="languages",
+                on_click=SessionState.toggle_language,
+            ),
+            profile_menu_item(
+                LanguageState.user_settings,
+                icon="cog",
+                on_click=rx.redirect(routes.USER_SETTINGS),
+            ),
+            profile_menu_item(
+                LanguageState.log_out,
+                icon="log-out",
+                on_click=SessionState.perform_logout,
+            ),
+        ),
+        rx.fragment(
+            profile_menu_item(
+                LanguageState.language_string,
+                icon="languages",
+                on_click=SessionState.toggle_language,
+            ),
+            profile_menu_item(
+                LanguageState.log_in,
+                icon="log-in",
+                on_click=lambda: rx.redirect(routes.LOGIN),
+            ),
+            profile_menu_item(
+                LanguageState.register,
+                icon="notepad-text",
+                on_click=lambda: rx.redirect(routes.REGISTER),
+            ),
+        ),
+    )
+
+
+def profile_menu() -> rx.Component:
+    """Create the profile menu component for the navigation bar."""
+
+    return rx.menu.root(
+        rx.menu.trigger(
+            rx.icon_button(
+                rx.icon(get_user_icon()),
+                size="2",
+                radius="full",
+                _hover={"cursor": "pointer"},
+                background_color=get_user_icon_color(),
+            ),
+        ),
+        rx.cond(
+            SessionState.is_authenticated,
+            rx.menu.content(
+                profile_menu_actions(),
+            ),
+            rx.menu.content(
+                profile_menu_actions(),
+            ),
+        ),
+        justify="end",
+    )

--- a/aitutor/pages/prompts/page.py
+++ b/aitutor/pages/prompts/page.py
@@ -20,7 +20,5 @@ def prompts_page() -> rx.Component:
     """Prompts page."""
     return rx.center(
         prompt_management(),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/reports/page.py
+++ b/aitutor/pages/reports/page.py
@@ -25,7 +25,5 @@ def reports_page() -> rx.Component:
             align="center",
             justify="center",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/token_analyzer/page.py
+++ b/aitutor/pages/token_analyzer/page.py
@@ -35,7 +35,5 @@ def token_analyzer_page() -> rx.Component:
             align="center",
             justify="center",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="100%",
+        class_name="page-frame",
     )

--- a/aitutor/pages/user_settings/page.py
+++ b/aitutor/pages/user_settings/page.py
@@ -21,7 +21,5 @@ def user_settings_page() -> rx.Component:
             align="center",
             justify="center",
         ),
-        margin_top="2em",
-        margin_bottom="2em",
-        width="90%",
+        class_name="page-frame",
     )

--- a/aitutor/utilities/filtering_components.py
+++ b/aitutor/utilities/filtering_components.py
@@ -76,7 +76,6 @@ def search_bar(state: type[FilterMixin]) -> rx.Component:
                 name="search_value",
                 placeholder=LanguageState.search_placeholder,
                 required=True,
-                max_width="60vw",
             ),
             rx.button(
                 rx.icon("plus"),
@@ -84,9 +83,11 @@ def search_bar(state: type[FilterMixin]) -> rx.Component:
             ),
             justify="center",
             align="center",
+            width="100%",
         ),
         on_submit=state.add_search_value,
         reset_on_submit=True,
+        class_name="app-search-form",
     )
 
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,212 @@
+:root {
+  --app-page-max-width: 1180px;
+  --app-page-gutter: clamp(1rem, 3vw, 2rem);
+  --app-border: color-mix(in srgb, var(--gray-6) 72%, transparent);
+  --app-surface: color-mix(in srgb, var(--gray-1) 88%, white);
+  --app-muted-surface: color-mix(in srgb, var(--gray-2) 84%, white);
+  --app-shadow: 0 1px 2px rgb(15 23 42 / 5%);
+  --app-primary: #2563eb;
+  --app-primary-hover: #1d4ed8;
+  --app-primary-contrast: #fff;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+.app-shell {
+  min-height: 100vh;
+  width: 100%;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--gray-2) 70%, white) 0, transparent 220px),
+    var(--gray-1);
+  color: var(--gray-12);
+}
+
+.app-main {
+  flex: 1;
+  width: 100%;
+}
+
+.site-navbar {
+  background: color-mix(in srgb, var(--gray-1) 92%, white);
+  border-bottom: 1px solid var(--app-border);
+  box-shadow: var(--app-shadow);
+}
+
+.site-footer {
+  width: 100%;
+  border-top: 1px solid var(--app-border);
+  background: color-mix(in srgb, var(--gray-1) 94%, white);
+  color: var(--gray-11);
+  flex-wrap: wrap;
+}
+
+.mobile-menu-trigger {
+  border: 1px solid var(--app-border);
+  background: var(--app-surface);
+  color: var(--gray-12);
+  box-shadow: var(--app-shadow);
+}
+
+.site-footer a {
+  color: var(--gray-11);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  color: var(--accent-11);
+  text-decoration: underline;
+}
+
+.page-frame {
+  width: min(100%, var(--app-page-max-width));
+  padding: 1.75rem var(--app-page-gutter);
+}
+
+.subnav-tabs-shell {
+  width: 100%;
+  overflow: hidden;
+  border-bottom: 1px solid var(--app-border);
+  background: color-mix(in srgb, var(--gray-1) 90%, white);
+}
+
+.subnav-tabs-list {
+  display: flex;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-7) transparent;
+}
+
+.subnav-tabs-list [role="tab"] {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.app-panel,
+.exercise-toolbar {
+  width: 100%;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow);
+}
+
+.exercise-toolbar {
+  padding: 0.5rem;
+}
+
+.exercise-toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.exercise-toolbar-group,
+.exercise-search-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.exercise-search-row {
+  justify-content: flex-end;
+}
+
+.app-search-form,
+.app-search-form > div {
+  width: 100%;
+}
+
+.app-search-form input {
+  width: min(26rem, 100%);
+}
+
+.page-frame .rt-TableRoot {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow);
+}
+
+.page-frame .rt-TableRoot table {
+  min-width: 38rem;
+}
+
+.rt-Card,
+.rt-AccordionRoot {
+  border-color: var(--app-border);
+  border-radius: 8px;
+  box-shadow: var(--app-shadow);
+}
+
+.rt-Button {
+  border-radius: 6px;
+  font-weight: 500;
+}
+
+.rt-Button:where([data-disabled]),
+.rt-Button:disabled {
+  background: var(--gray-4) !important;
+  color: var(--gray-9) !important;
+}
+
+.rt-TextFieldRoot,
+.rt-TextAreaRoot,
+.rt-SelectTrigger {
+  border-radius: 6px;
+}
+
+.rt-TableColumnHeaderCell {
+  background: var(--app-muted-surface);
+  color: var(--gray-12);
+  font-weight: 600;
+}
+
+.rt-TableCell,
+.rt-TableColumnHeaderCell {
+  padding-top: 0.8rem;
+  padding-bottom: 0.8rem;
+}
+
+.rt-TabsTrigger {
+  color: var(--gray-11);
+  font-weight: 500;
+}
+
+.rt-TabsTrigger[data-state="active"] {
+  color: var(--gray-12);
+}
+
+.rt-ProgressIndicator {
+  background: var(--app-primary);
+}
+
+@media (max-width: 560px) {
+  .page-frame {
+    padding: 1.25rem var(--app-page-gutter);
+  }
+
+  .exercise-toolbar-row,
+  .exercise-toolbar-group,
+  .exercise-search-row {
+    justify-content: stretch;
+  }
+
+  .exercise-toolbar-group > *,
+  .exercise-toolbar-row > *,
+  .exercise-search-row > * {
+    flex: 1 1 auto;
+  }
+}


### PR DESCRIPTION
## What

This is a first styling pass for review. It moves the app toward a calmer, more consistent workspace UI while keeping the existing Reflex/Radix component structure.

Main changes:

- Adds a global stylesheet for shared layout, shell, surfaces, tables, controls, and navigation styling.
- Pins the footer to the bottom of short pages and moves legal links there consistently.
- Improves page framing across dashboard, auth, lecture, exercise, admin, and settings pages.
- Makes admin and lecture tab bars horizontally scrollable instead of overflowing small viewports.
- Rearranges the manage exercises toolbar/search area for clearer scanning and better responsive behavior.
- Splits the large navbar module into focused link/profile helpers.
- Simplifies the small-screen header to one menu entry point, with account actions inside that menu and the theme toggle in the footer.

## Design review notes

This is intentionally a draft/WIP PR. I would like feedback on the visual direction before treating it as final, especially:

- whether the overall tone feels appropriately academic/professional,
- whether the blue primary color balance feels right,
- whether the manage exercises toolbar/table arrangement is clear enough,
- whether the mobile header/menu/footer behavior feels better than the previous header controls,
- whether any pages still feel too default/basic after this pass.

## Validation

- `uv run ruff check aitutor tests`
- `uv run pyright aitutor/pages/navbar.py aitutor/pages/navbar_links.py aitutor/pages/navbar_profile.py aitutor/pages/navbar_admin.py aitutor/pages/navbar_lectures.py aitutor/pages/manage_exercises/page.py aitutor/pages/exercises/page.py aitutor/utilities/filtering_components.py`
- `uv run pytest`
- Local browser review on `http://localhost:3001` across dashboard, login, lectures, manage exercises, and admin navigation.
