### PR TITLE
[codex] fix protected page auth flash

### DIFF
--- a/aitutor/pages/all_lectures/page.py
+++ b/aitutor/pages/all_lectures/page.py
@@ -10,9 +10,9 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_lectures import with_lectures_navbar
 
 
+@page_require_role_or_permission(required_role=UserRole.STUDENT)
 @with_navbar(routes.LECTURES)
 @with_lectures_navbar(routes.ALL_LECTURES)
-@page_require_role_or_permission(required_role=UserRole.STUDENT)
 def all_lectures_page() -> rx.Component:
     """Show the page scaffold for all available lectures."""
     return rx.center(

--- a/aitutor/pages/chat/page.py
+++ b/aitutor/pages/chat/page.py
@@ -16,8 +16,8 @@ from aitutor.pages.chat.state import ChatState
 from aitutor.pages.navbar import with_navbar
 
 
-@with_navbar(routes.EXERCISES)
 @page_require_role_or_permission(required_role=UserRole.STUDENT)
+@with_navbar(routes.EXERCISES)
 def chat_page() -> rx.Component:
     """Renders the web page."""
     return rx.container(

--- a/aitutor/pages/configuration/page.py
+++ b/aitutor/pages/configuration/page.py
@@ -10,9 +10,9 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_admin import with_admin_navbar
 
 
+@page_require_role_or_permission(required_role=UserRole.ADMIN)
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.CONFIGURATION)
-@page_require_role_or_permission(required_role=UserRole.ADMIN)
 def configuration_page() -> rx.Component:
     """Configuration page."""
     return rx.center(

--- a/aitutor/pages/edit_lecture/page.py
+++ b/aitutor/pages/edit_lecture/page.py
@@ -10,9 +10,9 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_lectures import with_lectures_navbar
 
 
+@page_require_role_or_permission(allowed_permissions=[GlobalPermission.LECTURER])
 @with_navbar(routes.LECTURES)
 @with_lectures_navbar(routes.EDIT_LECTURE + "/new")
-@page_require_role_or_permission(allowed_permissions=[GlobalPermission.LECTURER])
 def edit_lecture_page() -> rx.Component:
     """Lecture edit/create page."""
     return rx.center(

--- a/aitutor/pages/exercises/page.py
+++ b/aitutor/pages/exercises/page.py
@@ -11,8 +11,8 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.utilities.filtering_components import search_badges, search_bar
 
 
-@with_navbar(routes.EXERCISES)
 @page_require_role_or_permission(required_role=UserRole.STUDENT)
+@with_navbar(routes.EXERCISES)
 def exercises_page() -> rx.Component:
     """Default wrapper for exercises page"""
     return rx.center(

--- a/aitutor/pages/finished_view/page.py
+++ b/aitutor/pages/finished_view/page.py
@@ -13,8 +13,8 @@ from aitutor.pages.finished_view.state import FinishedViewState
 from aitutor.pages.navbar import with_navbar
 
 
-@with_navbar(routes.EXERCISES)
 @page_require_role_or_permission(required_role=UserRole.STUDENT)
+@with_navbar(routes.EXERCISES)
 def finished_view_page() -> rx.Component:
     """Renders the web page."""
     return rx.container(

--- a/aitutor/pages/finished_view_tutor/page.py
+++ b/aitutor/pages/finished_view_tutor/page.py
@@ -11,8 +11,8 @@ from aitutor.pages.finished_view_tutor.state import FinishedViewTutorState
 from aitutor.pages.navbar import with_navbar
 
 
-@with_navbar(routes.SUBMISSIONS)
 @page_require_role_or_permission(required_role=UserRole.TUTOR)
+@with_navbar(routes.SUBMISSIONS)
 def finished_view_tutor_page() -> rx.Component:
     """Renders the web page."""
     return rx.container(

--- a/aitutor/pages/manage_exercises/page.py
+++ b/aitutor/pages/manage_exercises/page.py
@@ -19,9 +19,9 @@ from aitutor.pages.navbar_admin import with_admin_navbar
 from aitutor.utilities.filtering_components import search_badges, search_bar
 
 
+@page_require_role_or_permission(required_role=UserRole.ADMIN)
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.MANAGE_EXERCISES)
-@page_require_role_or_permission(required_role=UserRole.ADMIN)
 def manage_exercises_page() -> rx.Component:
     """Manage exercises page."""
     return rx.center(

--- a/aitutor/pages/manage_users/page.py
+++ b/aitutor/pages/manage_users/page.py
@@ -10,12 +10,12 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_admin import with_admin_navbar
 
 
-@with_navbar(routes.ADMIN_SETTINGS)
-@with_admin_navbar(routes.MANAGE_USERS)
 @page_require_role_or_permission(
     required_role=UserRole.ADMIN,
     allowed_permissions=[GlobalPermission.MAINTAINER],
 )
+@with_navbar(routes.ADMIN_SETTINGS)
+@with_admin_navbar(routes.MANAGE_USERS)
 def manage_users_page() -> rx.Component:
     """Manage users page."""
     return rx.center(

--- a/aitutor/pages/my_lectures/page.py
+++ b/aitutor/pages/my_lectures/page.py
@@ -10,9 +10,9 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.navbar_lectures import with_lectures_navbar
 
 
+@page_require_role_or_permission(required_role=UserRole.STUDENT)
 @with_navbar(routes.LECTURES)
 @with_lectures_navbar(routes.MY_LECTURES)
-@page_require_role_or_permission(required_role=UserRole.STUDENT)
 def my_lectures_page() -> rx.Component:
     """Show the lectures visible to the current user."""
     return rx.center(

--- a/aitutor/pages/prompts/page.py
+++ b/aitutor/pages/prompts/page.py
@@ -10,12 +10,12 @@ from aitutor.pages.navbar_admin import with_admin_navbar
 from aitutor.pages.prompts.components import prompt_management
 
 
-@with_navbar(routes.ADMIN_SETTINGS)
-@with_admin_navbar(routes.PROMPTS)
 @page_require_role_or_permission(
     required_role=UserRole.ADMIN,
     allowed_permissions=[GlobalPermission.MAINTAINER],
 )
+@with_navbar(routes.ADMIN_SETTINGS)
+@with_admin_navbar(routes.PROMPTS)
 def prompts_page() -> rx.Component:
     """Prompts page."""
     return rx.center(

--- a/aitutor/pages/report_view/page.py
+++ b/aitutor/pages/report_view/page.py
@@ -11,8 +11,8 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.report_view.state import ReportViewState
 
 
-@with_navbar(routes.ADMIN_SETTINGS)
 @page_require_role_or_permission(required_role=UserRole.ADMIN)
+@with_navbar(routes.ADMIN_SETTINGS)
 def report_view_page() -> rx.Component:
     """Renders the report view page."""
     return rx.container(

--- a/aitutor/pages/reports/page.py
+++ b/aitutor/pages/reports/page.py
@@ -12,9 +12,9 @@ from aitutor.pages.reports.state import ReportsState
 from aitutor.utilities.filtering_components import search_badges, search_bar
 
 
+@page_require_role_or_permission(required_role=UserRole.ADMIN)
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.REPORTS)
-@page_require_role_or_permission(required_role=UserRole.ADMIN)
 def reports_page() -> rx.Component:
     """Page for tutors/admins to see all reports."""
     return rx.center(

--- a/aitutor/pages/submissions/page.py
+++ b/aitutor/pages/submissions/page.py
@@ -11,8 +11,8 @@ from aitutor.pages.submissions.state import SubmissionsState
 from aitutor.utilities.filtering_components import search_badges, search_bar
 
 
-@with_navbar(routes.SUBMISSIONS)
 @page_require_role_or_permission(required_role=UserRole.TUTOR)
+@with_navbar(routes.SUBMISSIONS)
 def submissions_page() -> rx.Component:
     """Manage exercises page."""
     return rx.center(

--- a/aitutor/pages/token_analyzer/page.py
+++ b/aitutor/pages/token_analyzer/page.py
@@ -18,9 +18,9 @@ from aitutor.pages.token_analyzer.state import (
 )
 
 
+@page_require_role_or_permission(required_role=UserRole.ADMIN)
 @with_navbar(routes.ADMIN_SETTINGS)
 @with_admin_navbar(routes.TOKEN_ANALYZER)
-@page_require_role_or_permission(required_role=UserRole.ADMIN)
 def token_analyzer_page() -> rx.Component:
     """Token analyzer page for user token usage overview."""
     return rx.center(

--- a/aitutor/pages/user_settings/page.py
+++ b/aitutor/pages/user_settings/page.py
@@ -9,8 +9,8 @@ from aitutor.pages.navbar import with_navbar
 from aitutor.pages.user_settings.components import change_password_card
 
 
-@with_navbar()
 @page_require_role_or_permission(required_role=UserRole.STUDENT)
+@with_navbar()
 def user_settings_page() -> rx.Component:
     """Page where the user can change their settings."""
     return rx.center(


### PR DESCRIPTION
## Summary
- wrap protected pages with `page_require_role_or_permission` outside page/navbar decorators
- prevent protected page chrome from rendering before the existing auth guard resolves

## Root cause
The auth guard was applied inside navbar/page wrapper decorators. The page body was gated, but protected route chrome could render briefly before `LoginState.redir` settled the unauthenticated session.

## Validation
- `uv run pytest`
- `uv run ruff check aitutor/pages`
- In-app browser smoke: unauthenticated `/lectures/edit_lecture/4` redirects to `/login`; no lecture edit data was observed during testing

Fixes #359