### PR TITLE
fix: reset session state on logout

### DIFF
--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -9,7 +9,6 @@ import reflex_local_auth
 from sqlmodel import select
 
 import aitutor.routes as routes
-from aitutor import pages
 from aitutor.models import GlobalPermission, Language, Permission, UserInfo, UserRole
 
 
@@ -75,24 +74,8 @@ class SessionState(reflex_local_auth.LocalAuthState):
         """
         Handles the logout process for the authenticated user.
         """
-        states = [
-            pages.ChatState,
-            pages.HomeState,
-            pages.ExercisesState,
-            pages.FinishedViewState,
-            pages.FinishedViewTutorState,
-            pages.ManageExercisesState,
-            pages.ManageTagsState,
-            pages.SubmissionsState,
-        ]
-        for state in states:
-            # get the state
-            state_instance = await self.get_state(state)
-            # clear the state
-            state_instance.on_logout()
-
-        # logout
         self.do_logout()
+        self.reset()
         return rx.redirect(routes.HOME, replace=True)
 
     @rx.var(cache=True, initial_value=None)


### PR DESCRIPTION
## Summary
- replace the manual logout cleanup list with Reflex's native `State.reset()` handling
- remove the fragile `aitutor.pages` import from `aitutor.auth.state`
- reset `SessionState` and its substates after invalidating the local auth session

## Root cause
`SessionState.perform_logout()` manually listed page state classes whose `on_logout()` methods should be called. New page states could be missed, leaving user-specific UI state cached after logout.

Reflex already provides `State.reset()`, which resets the current state and its substates. The page states inherit from `SessionState`, so this gives us the intended framework-level cleanup path without maintaining a parallel list.

## Validation
- `uv run ruff check aitutor/auth/state.py`
- `uv run pytest`
- In-app browser smoke: created a disposable local user, logged in, logged out, confirmed protected `/exercises` redirects to `/login`, logged in again, logged out again, then deleted the disposable user

Fixes #362
Fixes #363