### PR TITLE
Use OPENAI_BASE_URL if specifed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Create local environment file `.env` with the following content:
 
 ```bash
 OPENAI_API_KEY=<your key>
+OPENAI_BASE_URL=<url>  # optional, if using a different provider (instead of OpenAI)
 ```
 
 (Optional) Add your own `config.toml` file for the initial configuration. See [configfile documentation](docs/configfile.md) for more information.

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -159,24 +159,20 @@ def initialize():
 
     # load config here, so we fail immediately if there is any issue with it
     try:
-        config = get_config()
-        if config.course_name:
-            print("Configuration can be loaded successfully.")
+        _ = get_config()
     except Exception as e:
         print("\033[91m" + f"Error loading config: {e}" + "\033[0m")
         sys.exit(1)
 
     # check if an openai_key is in the .env, if not, we exit
-    API_KEY = decouple.config("OPENAI_API_KEY", cast=str, default="")
-    if API_KEY == "":
+    openai_api_key = decouple.config("OPENAI_API_KEY", cast=str, default="")
+    if openai_api_key == "":
         print(
             "\033[91m"
-            + "OPENAI_KEY is not set in the environment variables."
+            + "OPENAI_API_KEY is not set in the environment variables."
             + "\033[0m"
         )
         sys.exit(1)
-    else:
-        print("OPENAI_API_KEY found in environment variables.")
     openai_base_url = decouple.config("OPENAI_BASE_URL", cast=str, default="")
     if openai_base_url:
         print(f"Using OPENAI_BASE_URL={openai_base_url}")

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -177,6 +177,9 @@ def initialize():
         sys.exit(1)
     else:
         print("OPENAI_API_KEY found in environment variables.")
+    openai_base_url = decouple.config("OPENAI_BASE_URL", cast=str, default="")
+    if openai_base_url:
+        print(f"Using OPENAI_BASE_URL={openai_base_url}")
 
     create_default_users()
 

--- a/aitutor/config.py
+++ b/aitutor/config.py
@@ -120,9 +120,7 @@ def initialize_config_db():
             )
             session.add(config)
             session.commit()
-            print("Configuration row added to the database.")
-        else:
-            print("Configuration row exists in the database.")
+            print("Configuration added to the database.")
 
 
 def get_config() -> Config:

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -61,6 +61,19 @@ class CheckConversationResponse(BaseModel):
     check_passed: bool
 
 
+def init_async_openai_client() -> AsyncOpenAI:
+    """Initialize AsyncOpenAI client.
+
+    Uses decouple to get the API key and optionally base url, so they can be set either
+    as environment variables or in a .env file.
+    """
+    api_key = cast(str, decouple.config("OPENAI_API_KEY", cast=str))
+    base_url = cast(str, decouple.config("OPENAI_BASE_URL", cast=str, default=""))
+    base_url = base_url if base_url else None
+
+    return AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+
 async def get_chat_response(conversation):
     """
     Sends asynchronous requests to OpenAI.
@@ -71,12 +84,8 @@ async def get_chat_response(conversation):
     Returns:
         tuple: (response_text, tokens_used)
     """
-    API_KEY = cast(str, decouple.config("OPENAI_API_KEY", cast=str, default=""))
-    if API_KEY == "":
-        raise ValueError("API key not found.")
-
     # Creates GPT instance
-    client = AsyncOpenAI(api_key=API_KEY)
+    client = init_async_openai_client()
     # filter out messages with role 'check_result' from the conversation
     conversation = [
         msg for msg in conversation if msg["role"] != Role.CHECK_RESULT.value
@@ -132,10 +141,7 @@ async def get_check_conversation_response(
             "content": check_conversation_prompt,
         }
     )
-    API_KEY = cast(str, decouple.config("OPENAI_API_KEY", cast=str, default=""))
-    if API_KEY == "":
-        raise ValueError("API key not found.")
-    client = AsyncOpenAI(api_key=API_KEY)
+    client = init_async_openai_client()
     completion = await client.beta.chat.completions.parse(
         model=config.check_ai_model,
         messages=conversation,


### PR DESCRIPTION
It can be set as environment variable or in the `.env` file.  If set, its value is used when initializing the OpenAI client.

This can be used for using other LLM providers that support the same API.

I also reduced the output during initialisation a bit.  I don't think we need all the prints just saying that everything is okay.  Instead, only print if something is wrong or noteworthy (e.g. it might be good to mention if a custom base url is set).