### PR TITLE
feat(auth): add password reset flow

### DIFF
--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -1,0 +1,34 @@
+"""Account welcome email helpers."""
+
+from typing import cast
+
+from decouple import config
+from reflex_local_auth.user import LocalUser
+
+from aitutor.mail import send_text_email
+from aitutor.models import UserInfo
+
+
+def public_base_url() -> str:
+    """Public base URL used for links in account emails."""
+    return cast(
+        str, config("AITUTOR_PUBLIC_URL", default="http://localhost:3000", cast=str)
+    ).rstrip("/")
+
+
+def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
+    """Send a welcome email for a newly registered account."""
+    from aitutor.language_state import BackendTranslations as BT
+
+    if local_user.id is None:
+        raise ValueError("Cannot send welcome email before user is persisted.")
+    login_url = f"{public_base_url()}/login"
+    send_text_email(
+        to_email=user_info.email,
+        subject=BT.signup_welcome_subject(user_info.language),
+        body=BT.signup_welcome_body(
+            user_info.language,
+            username=local_user.username,
+            login_url=login_url,
+        ),
+    )

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -1,12 +1,41 @@
-"""Account welcome email helpers."""
+"""Account welcome email and password reset helpers."""
 
-from typing import cast
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from secrets import token_urlsafe
+from typing import Optional, cast
 
 from decouple import config
+from reflex_local_auth.auth_session import LocalAuthSession
 from reflex_local_auth.user import LocalUser
+from sqlmodel import Column, DateTime, Field, Session, SQLModel, col, select
 
-from aitutor.mail import send_text_email
+from aitutor.mail import SmtpSettings, send_text_email
 from aitutor.models import UserInfo
+
+PASSWORD_RESET = "password_reset"
+PASSWORD_RESET_TTL_HOURS = 2
+
+
+class AccountEmailToken(SQLModel, table=True):
+    """Hashed one-time account email token."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        foreign_key="localuser.id", nullable=False, ondelete="CASCADE", index=True
+    )
+    purpose: str = Field(nullable=False, index=True)
+    token_hash: str = Field(nullable=False, unique=True, index=True)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+    used_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
 
 
 def public_base_url() -> str:
@@ -14,6 +43,52 @@ def public_base_url() -> str:
     return cast(
         str, config("AITUTOR_PUBLIC_URL", default="http://localhost:3000", cast=str)
     ).rstrip("/")
+
+
+def hash_token(token: str) -> str:
+    """Return the irreversible hash stored for a one-time token."""
+    return sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_account_token(
+    session: Session, *, user_id: int, purpose: str, ttl_hours: int
+) -> str:
+    """Create a one-time account token and store only its hash."""
+    token = token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    session.add(
+        AccountEmailToken(
+            user_id=user_id,
+            purpose=purpose,
+            token_hash=hash_token(token),
+            created_at=now,
+            expires_at=now + timedelta(hours=ttl_hours),
+        )
+    )
+    return token
+
+
+def get_valid_token(
+    session: Session, *, token: str, purpose: str
+) -> AccountEmailToken | None:
+    """Return a valid unused token row, if any."""
+    token_row = session.exec(
+        select(AccountEmailToken).where(
+            AccountEmailToken.token_hash == hash_token(token),
+            AccountEmailToken.purpose == purpose,
+            col(AccountEmailToken.used_at).is_(None),
+        )
+    ).one_or_none()
+    if token_row is None:
+        return None
+    if token_row.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+        return None
+    return token_row
+
+
+def build_password_reset_link(token: str) -> str:
+    """Build a password reset link."""
+    return f"{public_base_url()}/reset_password/{token}"
 
 
 def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
@@ -32,3 +107,66 @@ def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
             login_url=login_url,
         ),
     )
+
+
+def send_password_reset(session: Session, *, identifier: str) -> None:
+    """Send a password reset email if the username or email exists."""
+    from aitutor.language_state import BackendTranslations as BT
+
+    settings = SmtpSettings.from_env()
+    row = session.exec(
+        select(LocalUser, UserInfo)
+        .join(UserInfo, col(UserInfo.user_id) == col(LocalUser.id))
+        .where(
+            (col(LocalUser.username) == identifier)
+            | (col(UserInfo.email) == identifier)
+        )
+    ).one_or_none()
+    if row is None:
+        return
+
+    local_user, user_info = row
+    if local_user.id is None:
+        return
+
+    token = create_account_token(
+        session,
+        user_id=local_user.id,
+        purpose=PASSWORD_RESET,
+        ttl_hours=PASSWORD_RESET_TTL_HOURS,
+    )
+    link = build_password_reset_link(token)
+    send_text_email(
+        to_email=user_info.email,
+        subject=BT.password_reset_subject(user_info.language),
+        body=BT.password_reset_body(
+            user_info.language,
+            username=local_user.username,
+            reset_link=link,
+            ttl_hours=PASSWORD_RESET_TTL_HOURS,
+        ),
+        settings=settings,
+    )
+
+
+def reset_password(session: Session, *, token: str, new_password: str) -> bool:
+    """Reset a user's password from a valid token and clear active sessions."""
+    token_row = get_valid_token(session, token=token, purpose=PASSWORD_RESET)
+    if token_row is None:
+        return False
+
+    local_user = session.get(LocalUser, token_row.user_id)
+    if local_user is None:
+        return False
+
+    now = datetime.now(timezone.utc)
+    local_user.password_hash = LocalUser.hash_password(new_password)
+    local_user.enabled = True
+    token_row.used_at = now
+
+    sessions = session.exec(
+        select(LocalAuthSession).where(LocalAuthSession.user_id == token_row.user_id)
+    ).all()
+    for auth_session in sessions:
+        session.delete(auth_session)
+    return True

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -124,6 +124,16 @@ app.add_page(
     route=routes.REGISTER,
     on_load=pages.MyRegisterState.on_load,
 )
+app.add_page(
+    pages.forgot_password_page,
+    route=routes.FORGOT_PASSWORD,
+    on_load=pages.ForgotPasswordState.on_load,
+)
+app.add_page(
+    pages.reset_password_page,
+    route=routes.RESET_PASSWORD + "/[token]",
+    on_load=pages.ResetPasswordState.on_load,
+)
 app.add_page(pages.not_found_page, route=routes.NOT_FOUND)
 app.add_page(pages.impressum_page, route=routes.IMPRESSUM)
 app.add_page(pages.privacy_notice_page, route=routes.PRIVACY_NOTICE)

--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -9,7 +9,6 @@ import reflex_local_auth
 from sqlmodel import select
 
 import aitutor.routes as routes
-from aitutor import pages
 from aitutor.models import GlobalPermission, Language, Permission, UserInfo, UserRole
 
 
@@ -75,6 +74,8 @@ class SessionState(reflex_local_auth.LocalAuthState):
         """
         Handles the logout process for the authenticated user.
         """
+        from aitutor import pages
+
         states = [
             pages.ChatState,
             pages.HomeState,

--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -24,6 +24,16 @@ def translate(language: Language, *, de: str, en: str) -> str:
             return en
 
 
+def language_from_value(value: object) -> Language:
+    """Parse a language value from form data, falling back to English."""
+    if isinstance(value, Language):
+        return value
+    try:
+        return Language(str(value))
+    except ValueError:
+        return Language.EN
+
+
 class LanguageState(SessionState):
     """State that returns all strings in the current language."""
 
@@ -835,6 +845,20 @@ class LanguageState(SessionState):
         )
 
     @rx.var
+    def successful_registration_with_email(self) -> str:
+        return self.translate(
+            de="Registrierung erfolgreich. Wir haben Ihnen eine Willkommens-E-Mail gesendet.",
+            en="Registration successful. We sent you a welcome email.",
+        )
+
+    @rx.var
+    def successful_registration_email_failed(self) -> str:
+        return self.translate(
+            de="Registrierung erfolgreich, aber die Willkommens-E-Mail konnte nicht gesendet werden.",
+            en="Registration successful, but the welcome email could not be sent.",
+        )
+
+    @rx.var
     def registration_code(self) -> str:
         """Registration Code string"""
         return self.translate(de="Registrierungscode", en="Registration code")
@@ -1516,6 +1540,37 @@ class BackendTranslations:
             language,
             de="Fehler: Das eingegebene Passwort ist falsch.",
             en="Error: The entered password is incorrect.",
+        )
+
+    # Account email flows ---------------------------------------------------------------
+    @staticmethod
+    def signup_welcome_subject(language: Language) -> str:
+        return translate(
+            language,
+            de="Willkommen bei AI Tutor",
+            en="Welcome to AI Tutor",
+        )
+
+    @staticmethod
+    def signup_welcome_body(
+        language: Language, *, username: str, login_url: str
+    ) -> str:
+        return translate(
+            language,
+            de=(
+                f"Hallo {username},\n\n"
+                "Ihr AI Tutor Konto wurde erfolgreich erstellt.\n\n"
+                f"Benutzername: {username}\n\n"
+                f"Sie können sich hier anmelden:\n{login_url}\n\n"
+                "Falls Sie dieses Konto nicht erstellt haben, kontaktieren Sie bitte das AI Tutor Team."
+            ),
+            en=(
+                f"Hello {username},\n\n"
+                "Your AI Tutor account has been created successfully.\n\n"
+                f"Username: {username}\n\n"
+                f"You can log in here:\n{login_url}\n\n"
+                "If you did not create this account, please contact the AI Tutor team."
+            ),
         )
 
     # ManageExercisesState -------------------------------------------------------------

--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -822,6 +822,33 @@ class LanguageState(SessionState):
         )
 
     @rx.var
+    def forgot_password(self) -> str:
+        return self.translate(de="Passwort vergessen?", en="Forgot password?")
+
+    @rx.var
+    def reset_password(self) -> str:
+        return self.translate(de="Passwort zurücksetzen", en="Reset password")
+
+    @rx.var
+    def username_or_email(self) -> str:
+        return self.translate(de="Benutzername oder E-Mail", en="Username or email")
+
+    @rx.var
+    def send_reset_link(self) -> str:
+        return self.translate(de="Link zum Zurücksetzen senden", en="Send reset link")
+
+    @rx.var
+    def set_new_password(self) -> str:
+        return self.translate(de="Neues Passwort festlegen", en="Set new password")
+
+    @rx.var
+    def confirm_new_password(self) -> str:
+        return self.translate(
+            de="Neues Passwort bestätigen",
+            en="Confirm new password",
+        )
+
+    @rx.var
     def password(self) -> str:
         """Password string"""
         return self.translate(de="Passwort", en="Password")
@@ -1542,7 +1569,63 @@ class BackendTranslations:
             en="Error: The entered password is incorrect.",
         )
 
-    # Account email flows ---------------------------------------------------------------
+    # Login, registration and account email flows --------------------------------------
+    @staticmethod
+    def enter_username_or_email(language: Language) -> str:
+        return translate(
+            language,
+            de="Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein.",
+            en="Enter your username or email address.",
+        )
+
+    @staticmethod
+    def password_reset_email_unavailable(language: Language) -> str:
+        return translate(
+            language,
+            de="Die E-Mail zum Zurücksetzen des Passworts ist derzeit nicht verfügbar. Bitte versuchen Sie es später erneut.",
+            en="Password reset email is not available right now. Please try again later.",
+        )
+
+    @staticmethod
+    def password_reset_requested_generic(language: Language) -> str:
+        return translate(
+            language,
+            de="Falls ein Konto mit diesem Benutzernamen oder dieser E-Mail existiert, wurde ein Link zum Zurücksetzen gesendet.",
+            en="If an account exists for that username or email, a reset link has been sent.",
+        )
+
+    @staticmethod
+    def enter_new_password(language: Language) -> str:
+        return translate(
+            language,
+            de="Geben Sie ein neues Passwort ein.",
+            en="Enter a new password.",
+        )
+
+    @staticmethod
+    def passwords_do_not_match(language: Language) -> str:
+        return translate(
+            language,
+            de="Die eingegebenen Passwörter stimmen nicht überein.",
+            en="The entered passwords do not match.",
+        )
+
+    @staticmethod
+    def reset_link_invalid_or_expired(language: Language) -> str:
+        return translate(
+            language,
+            de="Dieser Link zum Zurücksetzen ist ungültig oder abgelaufen.",
+            en="This reset link is invalid or has expired.",
+        )
+
+    @staticmethod
+    def password_changed_login_now(language: Language) -> str:
+        return translate(
+            language,
+            de="Ihr Passwort wurde geändert. Sie können sich jetzt anmelden.",
+            en="Your password was changed. You can now log in.",
+        )
+
     @staticmethod
     def signup_welcome_subject(language: Language) -> str:
         return translate(
@@ -1570,6 +1653,34 @@ class BackendTranslations:
                 f"Username: {username}\n\n"
                 f"You can log in here:\n{login_url}\n\n"
                 "If you did not create this account, please contact the AI Tutor team."
+            ),
+        )
+
+    @staticmethod
+    def password_reset_subject(language: Language) -> str:
+        return translate(
+            language,
+            de="AI Tutor Passwort zurücksetzen",
+            en="Reset your AI Tutor password",
+        )
+
+    @staticmethod
+    def password_reset_body(
+        language: Language, *, username: str, reset_link: str, ttl_hours: int
+    ) -> str:
+        return translate(
+            language,
+            de=(
+                f"Hallo {username},\n\n"
+                "Verwenden Sie diesen Link, um Ihr AI Tutor Passwort zurückzusetzen:\n\n"
+                f"{reset_link}\n\n"
+                f"Dieser Link läuft in {ttl_hours} Stunden ab. Falls Sie dies nicht angefordert haben, können Sie diese E-Mail ignorieren."
+            ),
+            en=(
+                f"Hello {username},\n\n"
+                "Use this link to reset your AI Tutor password:\n\n"
+                f"{reset_link}\n\n"
+                f"This link expires in {ttl_hours} hours. If you did not request it, you can ignore this email."
             ),
         )
 

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -1,0 +1,138 @@
+"""SMTP email helpers for account-related messages."""
+
+from dataclasses import dataclass
+from email.message import EmailMessage
+from smtplib import SMTP, SMTP_SSL, SMTPException
+from typing import Any, Callable, cast
+
+from decouple import config
+
+
+class EmailConfigurationError(RuntimeError):
+    """Raised when email sending is requested without valid SMTP settings."""
+
+
+class EmailDeliveryError(RuntimeError):
+    """Raised when an email could not be delivered through SMTP."""
+
+
+@dataclass(frozen=True)
+class SmtpSettings:
+    """Runtime SMTP settings loaded from the deployment environment."""
+
+    host: str
+    port: int
+    from_email: str
+    username: str = ""
+    password: str = ""
+    use_tls: bool = True
+    use_ssl: bool = False
+    timeout: int = 10
+
+    @classmethod
+    def from_env(cls) -> "SmtpSettings":
+        """Load and validate SMTP settings from environment variables."""
+        use_ssl = cast(bool, config("SMTP_USE_SSL", default=False, cast=bool))
+        settings = cls(
+            host=cast(str, config("SMTP_HOST", default="", cast=str)).strip(),
+            port=cast(
+                int, config("SMTP_PORT", default=465 if use_ssl else 587, cast=int)
+            ),
+            from_email=cast(
+                str, config("SMTP_FROM_EMAIL", default="", cast=str)
+            ).strip(),
+            username=cast(str, config("SMTP_USERNAME", default="", cast=str)).strip(),
+            password=cast(str, config("SMTP_PASSWORD", default="", cast=str)),
+            use_tls=cast(bool, config("SMTP_USE_TLS", default=not use_ssl, cast=bool)),
+            use_ssl=use_ssl,
+            timeout=cast(int, config("SMTP_TIMEOUT", default=10, cast=int)),
+        )
+        settings.validate()
+        return settings
+
+    def validate(self) -> None:
+        """Validate settings needed for SMTP delivery."""
+        if not self.host:
+            raise EmailConfigurationError("SMTP_HOST is required to send email.")
+        if not self.from_email:
+            raise EmailConfigurationError("SMTP_FROM_EMAIL is required to send email.")
+        if self.port <= 0:
+            raise EmailConfigurationError("SMTP_PORT must be greater than 0.")
+        if self.timeout <= 0:
+            raise EmailConfigurationError("SMTP_TIMEOUT must be greater than 0.")
+        if self.use_tls and self.use_ssl:
+            raise EmailConfigurationError(
+                "SMTP_USE_TLS and SMTP_USE_SSL cannot both be enabled."
+            )
+        if bool(self.username) != bool(self.password):
+            raise EmailConfigurationError(
+                "SMTP_USERNAME and SMTP_PASSWORD must be configured together."
+            )
+
+    @property
+    def uses_authentication(self) -> bool:
+        """Whether SMTP username/password authentication is configured."""
+        return bool(self.username and self.password)
+
+
+def build_text_email(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    settings: SmtpSettings | None = None,
+) -> EmailMessage:
+    """Build a plain text email message."""
+    active_settings = settings or SmtpSettings.from_env()
+    message = EmailMessage()
+    message["From"] = active_settings.from_email
+    message["To"] = to_email
+    message["Subject"] = subject
+    message.set_content(body)
+    return message
+
+
+def send_text_email(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    settings: SmtpSettings | None = None,
+) -> None:
+    """Build and send a plain text email message."""
+    active_settings = settings or SmtpSettings.from_env()
+    send_email(
+        build_text_email(
+            to_email=to_email,
+            subject=subject,
+            body=body,
+            settings=active_settings,
+        ),
+        settings=active_settings,
+    )
+
+
+def send_email(
+    message: EmailMessage,
+    *,
+    settings: SmtpSettings | None = None,
+    smtp_client_cls: Callable[..., Any] | None = None,
+) -> None:
+    """Send an email message through the configured SMTP server."""
+    active_settings = settings or SmtpSettings.from_env()
+    active_settings.validate()
+    client_cls = smtp_client_cls or (SMTP_SSL if active_settings.use_ssl else SMTP)
+
+    try:
+        with client_cls(
+            active_settings.host,
+            active_settings.port,
+            timeout=active_settings.timeout,
+        ) as smtp:
+            if active_settings.use_tls:
+                smtp.starttls()
+            if active_settings.uses_authentication:
+                smtp.login(active_settings.username, active_settings.password)
+            smtp.send_message(message)
+    except (OSError, SMTPException) as exc:
+        raise EmailDeliveryError("Failed to send email via SMTP.") from exc

--- a/aitutor/pages/__init__.py
+++ b/aitutor/pages/__init__.py
@@ -1,3 +1,11 @@
+from aitutor.pages.account_emails.page import (
+    forgot_password_page,
+    reset_password_page,
+)
+from aitutor.pages.account_emails.state import (
+    ForgotPasswordState,
+    ResetPasswordState,
+)
 from aitutor.pages.all_lectures.page import all_lectures_page
 from aitutor.pages.all_lectures.state import AllLecturesState
 from aitutor.pages.chat.page import chat_page
@@ -19,7 +27,10 @@ from aitutor.pages.login_and_registration.page import (
     custom_login_page,
     custom_register_page,
 )
-from aitutor.pages.login_and_registration.state import MyLoginState, MyRegisterState
+from aitutor.pages.login_and_registration.state import (
+    MyLoginState,
+    MyRegisterState,
+)
 from aitutor.pages.manage_exercises.page import manage_exercises_page
 from aitutor.pages.manage_exercises.state import ManageExercisesState, ManageTagsState
 from aitutor.pages.manage_users.page import manage_users_page
@@ -58,6 +69,8 @@ __all__ = [
     "finished_view_tutor_page",
     "custom_login_page",
     "custom_register_page",
+    "forgot_password_page",
+    "reset_password_page",
     "impressum_page",
     "privacy_notice_page",
     "user_settings_page",
@@ -80,6 +93,8 @@ __all__ = [
     "SubmissionsState",
     "MyLoginState",
     "MyRegisterState",
+    "ForgotPasswordState",
+    "ResetPasswordState",
     "UserSettingsState",
     "ManageConfigState",
     "EditLectureState",

--- a/aitutor/pages/account_emails/__init__.py
+++ b/aitutor/pages/account_emails/__init__.py
@@ -1,0 +1,11 @@
+"""Password reset page exports."""
+
+from aitutor.pages.account_emails.page import forgot_password_page, reset_password_page
+from aitutor.pages.account_emails.state import ForgotPasswordState, ResetPasswordState
+
+__all__ = [
+    "forgot_password_page",
+    "reset_password_page",
+    "ForgotPasswordState",
+    "ResetPasswordState",
+]

--- a/aitutor/pages/account_emails/components.py
+++ b/aitutor/pages/account_emails/components.py
@@ -1,0 +1,117 @@
+"""Components for password reset account email pages."""
+
+from typing import Literal
+
+import reflex as rx
+from reflex_local_auth.pages.components import MIN_WIDTH
+
+from aitutor import routes
+from aitutor.language_state import LanguageState
+from aitutor.pages.account_emails.state import ForgotPasswordState, ResetPasswordState
+from aitutor.pages.login_and_registration.components import input, password_input
+
+
+def account_callout(
+    message, color_scheme: Literal["green", "red"], icon: str
+) -> rx.Component:
+    """Render an account flow status message."""
+    return rx.callout(
+        message,
+        icon=icon,
+        color_scheme=color_scheme,
+        role="alert",
+        width="100%",
+    )
+
+
+def forgot_password_form() -> rx.Component:
+    """Render the password reset request form."""
+    return rx.form(
+        rx.vstack(
+            rx.input(
+                type="hidden",
+                name="language",
+                value=LanguageState.language,
+            ),
+            rx.heading(LanguageState.reset_password, size="7"),
+            rx.cond(
+                ForgotPasswordState.error_message != "",
+                account_callout(
+                    ForgotPasswordState.error_message,
+                    color_scheme="red",
+                    icon="triangle_alert",
+                ),
+            ),
+            rx.cond(
+                ForgotPasswordState.message != "",
+                account_callout(
+                    ForgotPasswordState.message,
+                    color_scheme="green",
+                    icon="check",
+                ),
+            ),
+            rx.text(LanguageState.username_or_email),
+            input(
+                "identifier",
+                placeholder=LanguageState.username_or_email,
+                required=True,
+            ),
+            rx.button(
+                LanguageState.send_reset_link,
+                width="100%",
+                _hover={"cursor": "pointer"},
+            ),
+            rx.center(rx.link(LanguageState.log_in, href=routes.LOGIN), width="100%"),
+            min_width=MIN_WIDTH,
+        ),
+        on_submit=ForgotPasswordState.request_password_reset,
+    )
+
+
+def reset_password_form() -> rx.Component:
+    """Render the form for setting a new password."""
+    return rx.form(
+        rx.vstack(
+            rx.input(
+                type="hidden",
+                name="language",
+                value=LanguageState.language,
+            ),
+            rx.heading(LanguageState.set_new_password, size="7"),
+            rx.cond(
+                ResetPasswordState.error_message != "",
+                account_callout(
+                    ResetPasswordState.error_message,
+                    color_scheme="red",
+                    icon="triangle_alert",
+                ),
+            ),
+            rx.cond(
+                ResetPasswordState.message != "",
+                account_callout(
+                    ResetPasswordState.message,
+                    color_scheme="green",
+                    icon="check",
+                ),
+            ),
+            rx.text(LanguageState.new_password),
+            password_input(
+                "new_password",
+                placeholder=LanguageState.new_password,
+                required=True,
+            ),
+            rx.text(LanguageState.confirm_new_password),
+            password_input(
+                "confirm_password",
+                placeholder=LanguageState.confirm_new_password,
+                required=True,
+            ),
+            rx.button(
+                LanguageState.change_password,
+                width="100%",
+                _hover={"cursor": "pointer"},
+            ),
+            min_width=MIN_WIDTH,
+        ),
+        on_submit=ResetPasswordState.reset_password,
+    )

--- a/aitutor/pages/account_emails/page.py
+++ b/aitutor/pages/account_emails/page.py
@@ -1,0 +1,31 @@
+"""Password reset pages."""
+
+import reflex as rx
+
+from aitutor.pages.account_emails.components import (
+    forgot_password_form,
+    reset_password_form,
+)
+from aitutor.pages.navbar import with_navbar
+
+
+@with_navbar()
+def forgot_password_page() -> rx.Component:
+    """Password reset request page."""
+    return rx.center(
+        rx.card(forgot_password_form()),
+        margin_top="2em",
+        margin_bottom="2em",
+        width="90%",
+    )
+
+
+@with_navbar()
+def reset_password_page() -> rx.Component:
+    """Password reset page."""
+    return rx.center(
+        rx.card(reset_password_form()),
+        margin_top="2em",
+        margin_bottom="2em",
+        width="90%",
+    )

--- a/aitutor/pages/account_emails/state.py
+++ b/aitutor/pages/account_emails/state.py
@@ -1,0 +1,84 @@
+"""State for password reset pages."""
+
+import reflex as rx
+
+import aitutor.routes as routes
+from aitutor.account_emails import reset_password, send_password_reset
+from aitutor.language_state import BackendTranslations as BT
+from aitutor.language_state import language_from_value
+from aitutor.mail import EmailConfigurationError, EmailDeliveryError
+
+
+class ForgotPasswordState(rx.State):
+    """State for requesting a password reset link."""
+
+    message: str = ""
+    error_message: str = ""
+
+    @rx.event
+    def on_load(self):
+        """Clear page messages."""
+        self.message = ""
+        self.error_message = ""
+
+    @rx.event
+    def request_password_reset(self, form_data):
+        """Send a reset link if the account exists."""
+        language = language_from_value(form_data.get("language"))
+        identifier = form_data["identifier"].strip()
+        self.error_message = ""
+        if not identifier:
+            self.error_message = BT.enter_username_or_email(language)
+            return rx.set_focus("identifier")
+
+        try:
+            with rx.session() as session:
+                send_password_reset(session, identifier=identifier)
+                session.commit()
+        except (EmailConfigurationError, EmailDeliveryError, OSError):
+            self.error_message = BT.password_reset_email_unavailable(language)
+            return
+
+        self.message = BT.password_reset_requested_generic(language)
+
+
+class ResetPasswordState(rx.State):
+    """State for resetting a password from an email link."""
+
+    message: str = ""
+    error_message: str = ""
+
+    @rx.event
+    def on_load(self):
+        """Clear reset form messages."""
+        self.message = ""
+        self.error_message = ""
+
+    @rx.event
+    def reset_password(self, form_data):
+        """Reset the password if the token is valid."""
+        language = language_from_value(form_data.get("language"))
+        new_password = form_data["new_password"]
+        confirm_password = form_data["confirm_password"]
+        if not new_password:
+            self.error_message = BT.enter_new_password(language)
+            return rx.set_focus("new_password")
+        if new_password != confirm_password:
+            self.error_message = BT.passwords_do_not_match(language)
+            return rx.set_value("confirm_password", "")
+
+        with rx.session() as session:
+            success = reset_password(
+                session,
+                token=getattr(self, "token", ""),
+                new_password=new_password,
+            )
+            session.commit()
+
+        if not success:
+            self.error_message = BT.reset_link_invalid_or_expired(language)
+            return
+
+        self.error_message = ""
+        self.message = BT.password_changed_login_now(language)
+        return rx.redirect(routes.LOGIN)

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -93,12 +93,26 @@ def register_success() -> rx.Component:
     """Render the successful registration message."""
     return rx.cond(
         MyRegisterState.success,
-        rx.callout(
-            LanguageState.successful_registration,
-            icon="check",
-            color_scheme="green",
-            role="alert",
-            width="100%",
+        rx.cond(
+            MyRegisterState.welcome_email_failed,
+            rx.callout(
+                LanguageState.successful_registration_email_failed,
+                icon="triangle_alert",
+                color_scheme="amber",
+                role="alert",
+                width="100%",
+            ),
+            rx.callout(
+                rx.cond(
+                    MyRegisterState.welcome_email_sent,
+                    LanguageState.successful_registration_with_email,
+                    LanguageState.successful_registration,
+                ),
+                icon="check",
+                color_scheme="green",
+                role="alert",
+                width="100%",
+            ),
         ),
     )
 
@@ -108,6 +122,11 @@ def register_form() -> rx.Component:
     privacy_notice = get_privacy_notice_short()
     return rx.form(
         rx.vstack(
+            rx.input(
+                type="hidden",
+                name="language",
+                value=LanguageState.language,
+            ),
             rx.heading(LanguageState.register_heading, size="7"),
             register_error(),
             register_success(),

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -61,6 +61,7 @@ def login_form() -> rx.Component:
                 placeholder=LanguageState.password,
                 required=True,
             ),
+            rx.link(LanguageState.forgot_password, href=routes.FORGOT_PASSWORD),
             rx.button(LanguageState.log_in, width="100%", _hover={"cursor": "pointer"}),
             rx.center(
                 rx.link(LanguageState.register, href=routes.REGISTER),

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -4,8 +4,12 @@ import re
 
 import reflex as rx
 import reflex_local_auth
+from reflex_local_auth.user import LocalUser
 
+from aitutor.account_emails import send_signup_welcome
 from aitutor.config import get_config
+from aitutor.language_state import language_from_value
+from aitutor.mail import EmailConfigurationError, EmailDeliveryError
 from aitutor.models import UserInfo, UserRole
 
 
@@ -30,6 +34,8 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     password: str = ""
     confirm_password: str = ""
     registration_code: str = ""
+    welcome_email_sent: bool = False
+    welcome_email_failed: bool = False
 
     @rx.event
     def set_username(self, value: str):
@@ -70,6 +76,8 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.password = ""
         self.confirm_password = ""
         self.registration_code = ""
+        self.welcome_email_sent = False
+        self.welcome_email_failed = False
 
     # This event handler must be named something besides `handle_registration`!!!
     @rx.event
@@ -83,6 +91,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         Returns:
             Any: The result of the registration process.
         """
+        language = language_from_value(form_data.get("language"))
         # check for allowed user name
         if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
             self.error_message = (
@@ -100,14 +109,30 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
 
         registration_result = self.handle_registration(form_data)
         if self.new_user_id >= 0:
-            self.clear_state_vars()
+            welcome_email_sent = False
+            welcome_email_failed = False
             with rx.session() as session:
-                session.add(
-                    UserInfo(
-                        email=form_data["email"],
-                        role=UserRole.STUDENT,
-                        user_id=self.new_user_id,
-                    )
+                local_user = session.get(LocalUser, self.new_user_id)
+                user_info = UserInfo(
+                    email=form_data["email"],
+                    role=UserRole.STUDENT,
+                    user_id=self.new_user_id,
+                    language=language,
                 )
+                session.add(user_info)
                 session.commit()
+                try:
+                    if local_user is not None:
+                        send_signup_welcome(
+                            local_user=local_user,
+                            user_info=user_info,
+                        )
+                        welcome_email_sent = True
+                except (EmailConfigurationError, EmailDeliveryError):
+                    welcome_email_failed = True
+            self.clear_state_vars()
+            self.welcome_email_sent = welcome_email_sent
+            self.welcome_email_failed = welcome_email_failed
+            self.success = True
+            self.error_message = ""
         return registration_result

--- a/aitutor/routes.py
+++ b/aitutor/routes.py
@@ -27,6 +27,8 @@ TOKEN_ANALYZER = ADMIN_SETTINGS + "/token_analyzer"
 REPORT_VIEW = REPORTS + "/report_view"
 
 USER_SETTINGS = "/user_settings"
+FORGOT_PASSWORD = "/forgot_password"
+RESET_PASSWORD = "/reset_password"
 
 LECTURES = "/lectures"
 MY_LECTURES = LECTURES + "/my_lectures"

--- a/alembic/versions/9f1b2c3d4e5f_add_account_email_tokens.py
+++ b/alembic/versions/9f1b2c3d4e5f_add_account_email_tokens.py
@@ -1,0 +1,55 @@
+"""add account email tokens
+
+Revision ID: 9f1b2c3d4e5f
+Revises: 7d4104f6fd42
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+# revision identifiers, used by Alembic.
+revision: str = "9f1b2c3d4e5f"
+down_revision: Union[str, None] = "7d4104f6fd42"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "accountemailtoken",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("purpose", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("token_hash", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["localuser.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("accountemailtoken", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_accountemailtoken_purpose"), ["purpose"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_accountemailtoken_token_hash"), ["token_hash"], unique=True
+        )
+        batch_op.create_index(
+            batch_op.f("ix_accountemailtoken_user_id"), ["user_id"], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("accountemailtoken", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_accountemailtoken_user_id"))
+        batch_op.drop_index(batch_op.f("ix_accountemailtoken_token_hash"))
+        batch_op.drop_index(batch_op.f("ix_accountemailtoken_purpose"))
+
+    op.drop_table("accountemailtoken")

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,6 +20,43 @@ Then open [https://localhost](https://localhost) in your browser to access the a
 
 The config files `config.toml` and `.env` are expected to be found in the projects root directory and are mounted into the container from the host system.  This means that the configuration can easily be changed without the need of rebuilding the images.
 
+## Email setup
+
+Signup welcome emails are sent through SMTP.  Configure the following values in
+`.env`:
+
+```
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_FROM_EMAIL="AI Tutor <noreply@example.com>"
+SMTP_USERNAME=your-smtp-user
+SMTP_PASSWORD=your-smtp-password
+SMTP_USE_TLS=true
+SMTP_USE_SSL=false
+SMTP_TIMEOUT=10
+AITUTOR_PUBLIC_URL=https://your-ai-tutor.example
+```
+
+`SMTP_USERNAME` and `SMTP_PASSWORD` are optional only if the SMTP server allows
+unauthenticated sending.  If one is set, the other must be set as well.
+
+For University of Tuebingen SMTP, the documented server is typically:
+
+```
+SMTP_HOST=smtpserv.uni-tuebingen.de
+SMTP_PORT=587
+SMTP_USE_TLS=true
+```
+
+The SMTP username may be the ZDV-ID rather than the visible email address.  In
+that case, set `SMTP_USERNAME` to the ZDV-ID and set `SMTP_FROM_EMAIL` to the
+actual sender address that should appear on account emails.
+
+Signup welcome emails use `AITUTOR_PUBLIC_URL` to build login links.  Set it to
+the public URL users open in their browser.
+
+Do not commit real SMTP credentials to the repository.
+
 
 ## Production environment with Postgresql
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -22,8 +22,8 @@ The config files `config.toml` and `.env` are expected to be found in the projec
 
 ## Email setup
 
-Signup welcome emails are sent through SMTP.  Configure the following values in
-`.env`:
+Signup welcome emails and password reset emails are sent through SMTP.
+Configure the following values in `.env`:
 
 ```
 SMTP_HOST=smtp.example.com
@@ -52,8 +52,9 @@ The SMTP username may be the ZDV-ID rather than the visible email address.  In
 that case, set `SMTP_USERNAME` to the ZDV-ID and set `SMTP_FROM_EMAIL` to the
 actual sender address that should appear on account emails.
 
-Signup welcome emails use `AITUTOR_PUBLIC_URL` to build login links.  Set it to
-the public URL users open in their browser.
+Password reset emails use `AITUTOR_PUBLIC_URL` to build reset links.  Set it to
+the public URL users open in their browser.  New users receive a short welcome
+email after registration.
 
 Do not commit real SMTP credentials to the repository.
 

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -1,0 +1,100 @@
+from email.message import EmailMessage
+
+import pytest
+from reflex_local_auth.user import LocalUser
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from aitutor.account_emails import send_signup_welcome
+from aitutor.language_state import BackendTranslations as BT
+from aitutor.models import Language, UserInfo, UserRole
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def create_user(session: Session, *, language: Language = Language.EN) -> LocalUser:
+    user = LocalUser(
+        username="student",
+        password_hash=LocalUser.hash_password("old-password"),
+        enabled=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    assert user.id is not None
+    session.add(
+        UserInfo(
+            user_id=user.id,
+            email="student@example.com",
+            role=UserRole.STUDENT,
+            language=language,
+        )
+    )
+    session.commit()
+    return user
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_message"),
+    [
+        (Language.EN, "Welcome to AI Tutor"),
+        (Language.DE, "Willkommen bei AI Tutor"),
+    ],
+)
+def test_account_email_backend_translations(language, expected_message):
+    assert expected_message in BT.signup_welcome_subject(language)
+
+
+def test_send_signup_welcome_sends_email(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        user = create_user(session)
+        user_info = session.exec(select(UserInfo)).one()
+
+        send_signup_welcome(local_user=user, user_info=user_info)
+
+    assert len(sent_messages) == 1
+    assert sent_messages[0]["To"] == "student@example.com"
+    assert sent_messages[0]["Subject"] == "Welcome to AI Tutor"
+    assert "Username: student" in sent_messages[0].get_content()
+    assert "https://ai-tutor.example/login" in sent_messages[0].get_content()
+
+
+def test_send_signup_welcome_uses_user_language(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        user = create_user(session, language=Language.DE)
+        user_info = session.exec(select(UserInfo)).one()
+
+        send_signup_welcome(local_user=user, user_info=user_info)
+
+    assert sent_messages[0]["Subject"] == "Willkommen bei AI Tutor"
+    body = sent_messages[0].get_content()
+    assert "Hallo student" in body
+    assert "Benutzername: student" in body
+    assert "https://ai-tutor.example/login" in body

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -1,10 +1,22 @@
+from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
 
 import pytest
+from reflex_local_auth.auth_session import LocalAuthSession
 from reflex_local_auth.user import LocalUser
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from aitutor.account_emails import send_signup_welcome
+from aitutor.account_emails import (
+    PASSWORD_RESET,
+    AccountEmailToken,
+    build_password_reset_link,
+    create_account_token,
+    get_valid_token,
+    hash_token,
+    reset_password,
+    send_password_reset,
+    send_signup_welcome,
+)
 from aitutor.language_state import BackendTranslations as BT
 from aitutor.models import Language, UserInfo, UserRole
 
@@ -37,15 +49,160 @@ def create_user(session: Session, *, language: Language = Language.EN) -> LocalU
     return user
 
 
+def require_user_id(user: LocalUser) -> int:
+    assert user.id is not None
+    return user.id
+
+
 @pytest.mark.parametrize(
     ("language", "expected_message"),
     [
-        (Language.EN, "Welcome to AI Tutor"),
-        (Language.DE, "Willkommen bei AI Tutor"),
+        (Language.EN, "If an account exists"),
+        (Language.DE, "Falls ein Konto"),
     ],
 )
 def test_account_email_backend_translations(language, expected_message):
-    assert expected_message in BT.signup_welcome_subject(language)
+    assert expected_message in BT.password_reset_requested_generic(language)
+
+
+def test_password_reset_link_uses_public_base_url(monkeypatch):
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example/")
+
+    assert build_password_reset_link("token-123") == (
+        "https://ai-tutor.example/reset_password/token-123"
+    )
+
+
+def test_account_token_stores_hash_only():
+    with make_session() as session:
+        user = create_user(session)
+        user_id = require_user_id(user)
+
+        token = create_account_token(
+            session,
+            user_id=user_id,
+            purpose=PASSWORD_RESET,
+            ttl_hours=2,
+        )
+        session.commit()
+
+        token_row = session.exec(select(AccountEmailToken)).one()
+        assert token_row.token_hash == hash_token(token)
+        assert token_row.token_hash != token
+        assert get_valid_token(session, token=token, purpose=PASSWORD_RESET) is not None
+
+
+def test_expired_or_used_token_is_not_valid():
+    with make_session() as session:
+        user = create_user(session)
+        user_id = require_user_id(user)
+        token = "raw-token"
+        now = datetime.now(timezone.utc)
+        session.add(
+            AccountEmailToken(
+                user_id=user_id,
+                purpose=PASSWORD_RESET,
+                token_hash=hash_token(token),
+                created_at=now - timedelta(hours=3),
+                expires_at=now - timedelta(hours=1),
+            )
+        )
+        session.commit()
+
+        assert get_valid_token(session, token=token, purpose=PASSWORD_RESET) is None
+
+        token_row = session.exec(select(AccountEmailToken)).one()
+        token_row.expires_at = now + timedelta(hours=1)
+        token_row.used_at = now
+        session.commit()
+
+        assert get_valid_token(session, token=token, purpose=PASSWORD_RESET) is None
+
+
+def test_reset_password_updates_hash_and_clears_sessions():
+    with make_session() as session:
+        user = create_user(session)
+        user_id = require_user_id(user)
+        token = create_account_token(
+            session,
+            user_id=user_id,
+            purpose=PASSWORD_RESET,
+            ttl_hours=2,
+        )
+        session.add(
+            LocalAuthSession(
+                user_id=user_id,
+                session_id="existing-session",
+                expiration=datetime.now(timezone.utc) + timedelta(days=1),
+            )
+        )
+        session.commit()
+
+        assert reset_password(session, token=token, new_password="new-password")
+        session.commit()
+
+        updated_user = session.get(LocalUser, user_id)
+        assert updated_user is not None
+        assert updated_user.verify("new-password")
+        assert session.exec(select(LocalAuthSession)).all() == []
+        assert get_valid_token(session, token=token, purpose=PASSWORD_RESET) is None
+
+
+def test_send_password_reset_sends_email_without_account_enumeration(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        create_user(session)
+
+        send_password_reset(session, identifier="student@example.com")
+        send_password_reset(session, identifier="missing@example.com")
+        session.commit()
+
+        assert len(sent_messages) == 1
+        assert sent_messages[0]["To"] == "student@example.com"
+        assert sent_messages[0]["Subject"] == "Reset your AI Tutor password"
+        assert (
+            "https://ai-tutor.example/reset_password/" in sent_messages[0].get_content()
+        )
+
+
+def test_send_password_reset_uses_user_language(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        create_user(session, language=Language.DE)
+
+        send_password_reset(session, identifier="student@example.com")
+        session.commit()
+
+    assert sent_messages[0]["Subject"] == "AI Tutor Passwort zurücksetzen"
+    body = sent_messages[0].get_content()
+    assert "Hallo student" in body
+    assert "Dieser Link läuft in 2 Stunden ab." in body
 
 
 def test_send_signup_welcome_sends_email(monkeypatch):

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,0 +1,128 @@
+from email.message import EmailMessage
+
+import pytest
+
+from aitutor.mail import (
+    EmailConfigurationError,
+    SmtpSettings,
+    build_text_email,
+    send_email,
+)
+
+
+class FakeSmtpClient:
+    """SMTP client test double that records calls without sending email."""
+
+    instances = []
+
+    def __init__(self, host, port, timeout):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.started_tls = False
+        self.login_args = None
+        self.sent_messages = []
+        FakeSmtpClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def starttls(self):
+        self.started_tls = True
+
+    def login(self, username, password):
+        self.login_args = (username, password)
+
+    def send_message(self, message):
+        self.sent_messages.append(message)
+
+
+def test_smtp_settings_from_env(monkeypatch):
+    monkeypatch.setenv("SMTP_HOST", "smtpserv.uni-tuebingen.de")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "AI Tutor <noreply@example.com>")
+    monkeypatch.setenv("SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("SMTP_PASSWORD", "smtp-password")
+    monkeypatch.setenv("SMTP_USE_TLS", "true")
+    monkeypatch.setenv("SMTP_USE_SSL", "false")
+
+    settings = SmtpSettings.from_env()
+
+    assert settings.host == "smtpserv.uni-tuebingen.de"
+    assert settings.port == 587
+    assert settings.from_email == "AI Tutor <noreply@example.com>"
+    assert settings.username == "smtp-user"
+    assert settings.password == "smtp-password"
+    assert settings.use_tls is True
+    assert settings.use_ssl is False
+    assert settings.uses_authentication is True
+
+
+def test_smtp_settings_require_host(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+
+    with pytest.raises(EmailConfigurationError, match="SMTP_HOST"):
+        SmtpSettings.from_env()
+
+
+def test_smtp_settings_reject_partial_credentials():
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="noreply@example.com",
+        username="smtp-user",
+    )
+
+    with pytest.raises(EmailConfigurationError, match="SMTP_USERNAME"):
+        settings.validate()
+
+
+def test_build_text_email_uses_configured_sender():
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="AI Tutor <noreply@example.com>",
+    )
+
+    message = build_text_email(
+        to_email="student@example.com",
+        subject="Confirm your AI Tutor account",
+        body="Welcome to AI Tutor.",
+        settings=settings,
+    )
+
+    assert message["From"] == "AI Tutor <noreply@example.com>"
+    assert message["To"] == "student@example.com"
+    assert message["Subject"] == "Confirm your AI Tutor account"
+    assert message.get_content() == "Welcome to AI Tutor.\n"
+
+
+def test_send_email_uses_starttls_and_authentication():
+    FakeSmtpClient.instances.clear()
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="noreply@example.com",
+        username="smtp-user",
+        password="smtp-password",
+        use_tls=True,
+    )
+    message = EmailMessage()
+    message["From"] = settings.from_email
+    message["To"] = "student@example.com"
+    message["Subject"] = "Test"
+    message.set_content("Body")
+
+    send_email(message, settings=settings, smtp_client_cls=FakeSmtpClient)
+
+    client = FakeSmtpClient.instances[0]
+    assert client.host == "smtp.example.com"
+    assert client.port == 587
+    assert client.timeout == 10
+    assert client.started_tls is True
+    assert client.login_args == ("smtp-user", "smtp-password")
+    assert client.sent_messages == [message]


### PR DESCRIPTION
## Summary
- split the password reset flow out of #351
- add forgot-password and reset-password pages/routes
- store one-time reset tokens as hashes with expiry/used state
- send localized reset emails through the shared SMTP helper
- invalidate active sessions after a successful reset

## Notes
- Depends on #351 for the shared SMTP helper and signup welcome email support. Until #351 lands, this PR will show those shared changes in the diff as well.

Closes #350

## Checks
- `uv run ruff check aitutor/account_emails.py aitutor/mail.py aitutor/auth/state.py aitutor/pages/account_emails aitutor/pages/login_and_registration/components.py aitutor/pages/login_and_registration/state.py aitutor/language_state.py tests/test_account_emails.py tests/test_mail.py`
- `uv run pytest tests/test_mail.py tests/test_account_emails.py`