### PR TITLE
docs: add coding agent guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report broken or unexpected behavior.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken, and what should happen instead?
+      placeholder: The registration page redirects before the warning can be read.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reliable reproduction path.
+      placeholder: |
+        1. Start the app with ...
+        2. Open ...
+        3. Click ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should the user see or what state should the system reach?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include visible errors, terminal logs, screenshots, or browser console output when relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, database backend, deployment mode, and relevant configuration.
+      placeholder: |
+        Browser:
+        Database: SQLite / PostgreSQL
+        Run mode: local / Docker / production
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checks that should be true after the fix.
+      placeholder: |
+        - The warning remains visible after email delivery fails.
+        - The terminal logs the SMTP failure.
+        - A regression test covers the failed delivery path.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Propose a user-visible feature or behavior change.
+title: "feat: "
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What user or maintainer problem should this solve?
+      placeholder: Tutors need to see which submissions exceeded the token limit.
+    validations:
+      required: true
+  - type: textarea
+    id: users
+    attributes:
+      label: Users and workflow
+      description: Who uses this, and where in the app does it fit?
+      placeholder: Admins use this from the configuration page before a course starts.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful version. Note any UI, auth, config, or database impact.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checks that would make the feature complete.
+      placeholder: |
+        - Lecturers can filter reports by unresolved status.
+        - Students cannot access the report management page.
+        - The changed flow has a focused test or documented manual check.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should stay out of scope for the first PR?
+      placeholder: Do not redesign the whole reports page in this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/technical_task.yml
+++ b/.github/ISSUE_TEMPLATE/technical_task.yml
@@ -1,0 +1,41 @@
+name: Technical task
+description: Track refactoring, maintenance, tests, documentation, or developer workflow work.
+title: "chore: "
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should be improved, and why now?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the intended files, modules, or behavior boundaries.
+      placeholder: |
+        In scope:
+        - ...
+        Out of scope:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checks that show the task is done.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Expected validation
+      description: Tests, lint, type checks, migration checks, or manual app checks expected for the task.
+      placeholder: |
+        - uv run ruff check ...
+        - uv run pytest ...
+        - Manual check: ...
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Objective
+
+<!-- What problem does this PR solve? Link the issue when possible. -->
+
+Closes #
+
+## Scope
+
+<!-- Keep this focused. List what changed and what intentionally stayed out of scope. -->
+
+Changed:
+
+Out of scope:
+
+## Acceptance Criteria
+
+<!-- Copy from the issue or state the concrete checks this PR should satisfy. -->
+
+- [ ] The implementation satisfies the linked issue or the criteria below.
+- [ ] Relevant error, loading, and permission states are covered or not applicable.
+
+## Verification
+
+<!-- List commands run and manual checks performed. Be precise about what was not run. -->
+
+- [ ] `uv run ruff check <changed files>`
+- [ ] `uv run pytest <relevant tests>`
+- [ ] `uv run pyright <changed files or aitutor>`
+- [ ] Manual app check:
+
+## UI / Runtime Evidence
+
+<!-- Required for UI, routing, auth, form, upload, loading/error-state, or Reflex behavior changes. Add screenshots or explain why not applicable. -->
+
+- Screenshots:
+- Browser/console check:
+
+## Review Notes
+
+<!-- Call out Reflex quirks, private APIs, migrations, provider compatibility, or risky tradeoffs. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guidance
+
+This repository is shared by humans and coding agents. Other branches or threads may leave unrelated local changes behind. Inspect the real state before acting, then keep your own edits narrow and reviewable.
+
+## Default Workflow
+
+- Work from the user's requested base branch. For new PRs, prefer a branch from `upstream/main` unless the user asks otherwise.
+- Read the relevant local context first: `README.md`, `docs/contribute.md`, `docs/architecture.md`, nearby page/state/component files, and related tests.
+- Keep diffs surgical. Do not clean up unrelated code, formatting, comments, or dead code unless the current change requires it.
+- Prefer small, reviewable PRs. Split independent behavior into follow-up PRs instead of bundling features.
+- Do not add speculative fallbacks, mock data, placeholder tests, broad configurability, or unused helpers.
+- Avoid making already-large files larger when a focused helper or module is the cleaner local fit. New files should stay small and have one clear responsibility.
+- Match the existing Reflex architecture: page folders usually contain `page.py`, `components.py`, and `state.py`; state classes should keep load/logout, computed vars, and action methods easy to scan.
+- Handle user-visible failures explicitly. Loading states, errors, and warnings should remain visible long enough to be useful.
+- Run the narrowest meaningful verification for the change and report exactly what passed or could not be run.
+
+## Repo-Specific Skills
+
+- For implementation work, read and follow `skills/ai-tutor-implementation/SKILL.md`.
+- Before finalizing nontrivial changes, create or use a separate review-only thread and read `skills/ai-tutor-review/SKILL.md`.
+- For UI, routing, auth, form, or Reflex state changes, the review thread should run the app and inspect the changed screens when feasible.
+
+## Reviewer Expectations
+
+Reviewers in this repository value small scope, clear code, real behavior checks, and removal of unnecessary code. Common review themes include:
+
+- Prefer database filtering/sorting over Python post-processing when the database can do it clearly.
+- Avoid duplicated state that can drift out of sync.
+- Be cautious with Reflex state reset, substates, dynamic routing, computed vars, and type-checking limitations.
+- Avoid private APIs from dependencies unless there is no reasonable public path and the reason is documented in the PR.
+- For Alembic changes, consider both SQLite and PostgreSQL. Existing migrations often need SQLite foreign-key handling when altering tables.
+- Keep translations centralized in `aitutor/language_state.py` / `BackendTranslations` when strings are user-visible.
+- Remove obsolete states, guards, branches, or tests rather than leaving them for reviewers to find.
+
+## Git And PR Hygiene
+
+- If asked to commit, consider all tracked and untracked changes, then create logical commit groups instead of one large mixed commit.
+- Use conventional commit prefixes such as `fix:`, `feat:`, `docs:`, and scoped variants like `fix(auth):`.
+- Do not post GitHub comments or mark review threads resolved unless the user asked for that live action.
+- When explaining AI-assisted work, be transparent that the human is responsible for the submitted code and comments.

--- a/skills/ai-tutor-implementation/SKILL.md
+++ b/skills/ai-tutor-implementation/SKILL.md
@@ -29,7 +29,7 @@ Use this skill to make repo-native changes that match the expectations shown in 
 - Preserve the page folder pattern: `page.py` for route/page composition, `components.py` for UI helpers, and `state.py` for event and data logic.
 - Keep state values minimal. Avoid duplicating route IDs, database values, or derived flags that can drift out of sync.
 - Add new user-specific state to logout/reset handling when needed. Do not reset session-independent preferences, such as language, by accident.
-- Prefer public APIs from Reflex and `reflex-local-auth`. If a private method is unavoidable, keep the call isolated and explain why in the PR.
+- Prefer public APIs from third-party packages. If a private method is unavoidable, keep the call isolated and explain why in the PR.
 - Computed vars that touch database-backed state may need explicit initial values for frontend builds.
 - Expect pyright and Reflex to disagree sometimes. Use `# type: ignore` only when the runtime behavior is verified and a clearer typed structure is not practical.
 

--- a/skills/ai-tutor-implementation/SKILL.md
+++ b/skills/ai-tutor-implementation/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ai-tutor-implementation
+description: Implement focused changes in the ai-tutor repository. Use when adding or modifying Python, Reflex UI/state, authentication, configuration, database models, Alembic migrations, tests, documentation, or other behavior in this repo.
+---
+
+# AI Tutor Implementation
+
+## Overview
+
+Use this skill to make repo-native changes that match the expectations shown in prior ai-tutor reviews: small scope, clear Reflex state boundaries, visible error handling, meaningful tests, and no dead or speculative code.
+
+## Start With Context
+
+- Confirm the current branch and dirty worktree before editing. Ignore unrelated changes unless they block the task.
+- Read the files that define the local pattern before changing code. For page work, inspect the relevant `page.py`, `components.py`, `state.py`, and nearby tests.
+- Read `docs/architecture.md` before adding pages, state classes, routes, or database-backed behavior.
+- Check recent PR/reviewer context when the task follows up on GitHub review comments.
+
+## Keep Scope Reviewable
+
+- Implement the smallest complete change that satisfies the request.
+- Split independent features, large flows, or cleanup into follow-up PRs instead of bundling them.
+- Do not add placeholder UI, mock data, speculative fallbacks, unused config, or tests that only check for strings unless that string output is the real contract.
+- Remove code made obsolete by your change. Do not leave duplicate paths for reviewers to find.
+- Prefer focused modules over growing files that are already hard to scan. If touching a large file, keep the edit local and consider extracting new behavior into a small helper file.
+
+## Reflex And State
+
+- Preserve the page folder pattern: `page.py` for route/page composition, `components.py` for UI helpers, and `state.py` for event and data logic.
+- Keep state values minimal. Avoid duplicating route IDs, database values, or derived flags that can drift out of sync.
+- Add new user-specific state to logout/reset handling when needed. Do not reset session-independent preferences, such as language, by accident.
+- Prefer public APIs from Reflex and `reflex-local-auth`. If a private method is unavoidable, keep the call isolated and explain why in the PR.
+- Computed vars that touch database-backed state may need explicit initial values for frontend builds.
+- Expect pyright and Reflex to disagree sometimes. Use `# type: ignore` only when the runtime behavior is verified and a clearer typed structure is not practical.
+
+## Data And Configuration
+
+- Let the database filter, sort, and join data when that is clearer and avoids Python-side drift.
+- Validate inputs at the boundary where users or config write values. Avoid repeated defensive correction when reading already-validated config.
+- Keep user-visible strings in the existing translation system, usually `aitutor/language_state.py` or `BackendTranslations`.
+- For settings, preserve actual deployment behavior. `.env` is read from the process working directory; production and Docker paths may differ from source-file-relative paths.
+- For OpenAI-compatible providers, treat normal chat and structured-output checks as separate compatibility surfaces.
+
+## Database Migrations
+
+- Generate migrations with `uv run reflex db makemigrations` when possible, then inspect the result.
+- Consider both SQLite and PostgreSQL. SQLite table alteration can recreate tables and may need foreign-key handling as seen in existing Alembic scripts.
+- Use PostgreSQL-compatible defaults for booleans and constraints where relevant.
+- Do not include migrations for unrelated model changes.
+
+## Verification
+
+- Run the narrowest meaningful command for the touched code.
+- Common checks include:
+  - `uv run ruff check <changed files>`
+  - `uv run pyright <changed files or package>` when the change affects typed backend logic
+  - `uv run pytest <relevant test files or test names>`
+  - `uv run reflex run` for interactive UI/runtime validation
+- Report exactly which checks passed and which were skipped.
+- After implementation, use `skills/ai-tutor-review/SKILL.md` in a separate review-only thread before finalizing substantial changes.

--- a/skills/ai-tutor-implementation/agents/openai.yaml
+++ b/skills/ai-tutor-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Tutor Implementation"
+  short_description: "Implement ai-tutor changes with repo guardrails"
+  default_prompt: "Use $ai-tutor-implementation to implement a focused ai-tutor change."

--- a/skills/ai-tutor-review/SKILL.md
+++ b/skills/ai-tutor-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ai-tutor-review
+description: Review ai-tutor changes before finalizing a PR. Use after implementation to inspect diffs, find dead code and scope creep, run targeted checks, and perform browser/screenshot validation for UI, routing, auth, form, or Reflex state changes.
+---
+
+# AI Tutor Review
+
+## Overview
+
+Use this skill in a review-only pass after implementation. The goal is to catch the issues that have repeatedly made ai-tutor PRs harder to review: oversized scope, dead code, duplicated state, weak tests, Reflex runtime surprises, and UI behavior that was not exercised.
+
+## Review Mode Rules
+
+- Start from `git status --short --branch` and `git diff --stat`.
+- Review only the implementation diff unless the user explicitly expands scope.
+- Do not make broad cleanup edits. If fixes are needed, keep them targeted to findings from the review.
+- Lead the final review output with findings, ordered by severity, with file and line references.
+- If there are no findings, say so and state residual risks or unverified paths.
+
+## Diff Review Checklist
+
+- Scope: Does the diff include independent features or cleanup that should be split out?
+- Dead code: Are there unused helpers, obsolete branches, redundant config values, old tests, or duplicate state fields?
+- Reflex state: Can reset/logout behavior clear data that should persist, or leave sensitive/user-specific state behind?
+- Dependency APIs: Does the change call private methods or rely on undocumented Reflex behavior without a reason?
+- Data flow: Can a duplicated ID/value drift from the route or database source of truth?
+- Database: Are filtering, sorting, joins, and uniqueness handled in the database when appropriate?
+- Migrations: Are SQLite and PostgreSQL both considered, especially foreign keys, constraints, and boolean defaults?
+- Translations: Are user-visible strings centralized in the existing language system?
+- Errors: Are failures logged or displayed clearly, and do warnings stay visible long enough to read?
+- Tests: Do tests exercise behavior rather than implementation text, and are they scoped to the change?
+
+## Runtime And Screenshot Review
+
+Use this section when the diff changes UI, routing, auth protection, forms, upload flows, loading/error states, Reflex state behavior, or generated frontend output.
+
+- Run the app with `uv run reflex run` unless the environment lacks required secrets or setup.
+- Open the changed screen in a browser.
+- Exercise the changed interaction, including the main failure path when feasible.
+- Capture screenshots of the changed screen or flow.
+- Check browser console and terminal output for Reflex/runtime errors.
+- Look for flicker, invisible loading, unreadable warnings, broken hover/dialog nesting, clipped text, and inconsistent desktop/mobile behavior.
+- Report which screens and interactions were checked. Do not claim full E2E coverage from a narrow smoke test.
+
+## Targeted Commands
+
+Pick the smallest meaningful set for the diff:
+
+- `uv run ruff check <changed files>`
+- `uv run pyright <changed files or aitutor>`
+- `uv run pytest <relevant tests>`
+- `uv run reflex run`
+- `git diff --check`
+
+If a command cannot run, record the exact reason and what review coverage remains.
+
+## Reviewer Pattern Reminders
+
+- Smaller PRs are easier to review; recommend splitting when the diff mixes concerns.
+- Simpler code is preferred over clever local state, private API calls, and broad guards.
+- Reflex behavior should be tested in the app when the change depends on generated frontend/runtime behavior.
+- Database migrations need extra care because production may use PostgreSQL while local development often uses SQLite.
+- If AI-generated code left an obvious quirk, naming inconsistency, or redundant path, call it out before the human reviewer has to.

--- a/skills/ai-tutor-review/agents/openai.yaml
+++ b/skills/ai-tutor-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Tutor Review"
+  short_description: "Review ai-tutor diffs and UI behavior"
+  default_prompt: "Use $ai-tutor-review to review an ai-tutor implementation before finalizing."


### PR DESCRIPTION
## Summary

Adds repo-native guidance for coding-agent work:

- `AGENTS.md` with general expectations for small, surgical, reviewable changes.
- `skills/ai-tutor-implementation` for implementation workflows in this Reflex app.
- `skills/ai-tutor-review` for a separate review-only pass after implementation, including runtime/screenshot review for UI changes.

The skills are checked into `skills/` so they are visible in the repository rather than hidden in local Codex config.

## Review notes

This is intentionally documentation-only. The guidance is based on recurring review themes in recent and closed PRs: keep PRs small, avoid dead code and duplicated state, handle Reflex-specific behavior carefully, verify UI/runtime behavior when relevant, and make review comments easier by catching obvious AI quirks before submission.

## Validation

- `python /Users/sebastianboehler/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/ai-tutor-implementation`
- `python /Users/sebastianboehler/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/ai-tutor-review`
- `rg -n "TODO|TBD|\\[TODO|\\.codex" AGENTS.md skills`
- `git diff --check`
- Separate review-only subagent inspected the staged diff and reported no findings.
