### PR TITLE
auto-focus login form

### DIFF
--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -54,6 +54,7 @@ def login_form() -> rx.Component:
                 "username",
                 placeholder=LanguageState.username,
                 required=True,
+                auto_focus=True,
                 custom_attrs={"auto_complete": "username"},
             ),
             rx.text(LanguageState.password),


### PR DESCRIPTION
When entering the login page, the username input field is automatically focused (so no need to klick on it).