### PR TITLE
Use centralized methods to access route parameters

### DIFF
--- a/aitutor/auth/protection.py
+++ b/aitutor/auth/protection.py
@@ -39,7 +39,7 @@ class LectureAccessState(SessionState):
             return True
 
         try:
-            lecture_id = int(self.lecture_id)
+            lecture_id = int(self.get_route_param_or_default("lecture_id", default=""))
         except ValueError:
             return False
 
@@ -223,7 +223,9 @@ def state_require_lecture_role(required_role: LectureRole):
                 return
 
             try:
-                lecture_id = int(self.lecture_id)
+                lecture_id = int(
+                    self.get_route_param_or_default("lecture_id", default="")
+                )
             except ValueError:
                 return
 

--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -158,6 +158,12 @@ class SessionState(reflex_local_auth.LocalAuthState):
             or GlobalPermission.ADMIN in self.global_permissions
         )
 
+    def _get_router_params(self) -> dict[str, str]:
+        # Wrap this in a method so we only directly access self.router.page in one
+        # place.  RouterData.page is deprecated and thus triggers a deprecation warning.
+        # However, the suggestion to use RouterData.url instead is not helpful, as it
+        # does not (yet?) provide access to the route parameters.
+        return self.router.page.params
 
     def get_route_param_or_default[T](
         self, param_name: str, default: T, dtype: Callable[..., T] = str
@@ -169,8 +175,8 @@ class SessionState(reflex_local_auth.LocalAuthState):
             default_value: The value to return if the parameter is not present.
             output_type: The type to which the parameter value should be cast.
         """
-        if param_name in self.router.page.params:
-            return dtype(self.router.page.params[param_name])
+        if param_name in self._get_router_params():
+            return dtype(self._get_router_params()[param_name])
         else:
             return default
 
@@ -186,6 +192,6 @@ class SessionState(reflex_local_auth.LocalAuthState):
         Raises:
             KeyError: If the parameter is not provided in the route.
         """
-        if param_name not in self.router.page.params:
+        if param_name not in self._get_router_params():
             raise KeyError(f"Route parameter '{param_name}' not found.")
-        return dtype(self.router.page.params[param_name])
+        return dtype(self._get_router_params()[param_name])

--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -2,7 +2,7 @@
 The state for managing user sessions.
 """
 
-from typing import Optional
+from typing import Callable, Optional
 
 import reflex as rx
 import reflex_local_auth
@@ -157,3 +157,35 @@ class SessionState(reflex_local_auth.LocalAuthState):
             permission in self.global_permissions
             or GlobalPermission.ADMIN in self.global_permissions
         )
+
+
+    def get_route_param_or_default[T](
+        self, param_name: str, default: T, dtype: Callable[..., T] = str
+    ) -> T:
+        """Get a route parameter or return a default value if not present.
+
+        Args:
+            param_name: The name of the route parameter to retrieve.
+            default_value: The value to return if the parameter is not present.
+            output_type: The type to which the parameter value should be cast.
+        """
+        if param_name in self.router.page.params:
+            return dtype(self.router.page.params[param_name])
+        else:
+            return default
+
+    def get_route_param_or_error[T](
+        self, param_name: str, dtype: Callable[..., T] = str
+    ) -> T:
+        """Get a route parameter or raise an error if not present.
+
+        Args:
+            param_name: The name of the route parameter to retrieve.
+            output_type: The type to which the parameter value should be cast.
+
+        Raises:
+            KeyError: If the parameter is not provided in the route.
+        """
+        if param_name not in self.router.page.params:
+            raise KeyError(f"Route parameter '{param_name}' not found.")
+        return dtype(self.router.page.params[param_name])

--- a/aitutor/pages/all_lectures/state.py
+++ b/aitutor/pages/all_lectures/state.py
@@ -157,15 +157,17 @@ class AllLecturesState(SessionState):
         self._reset_page_state()
         self.load_lectures()
 
-        lecture_id_param = self._get_route_lecture_id_param()
-        if not lecture_id_param:
+        lecture_id_str = self.get_route_param_or_default("lecture_id", default="")
+        if not lecture_id_str:
+            # this is the normal case where no lecture is specified, so we just show the
+            # list of lectures
             return
 
+        # in case a lecture is given as parameter, open the join dialog for that lecture
         try:
-            lecture_id = int(lecture_id_param)
+            lecture_id = int(lecture_id_str)
         except ValueError:
             return rx.redirect(routes.NOT_FOUND)
-
         return self.open_join_dialog(lecture_id)
 
     def on_logout(self):
@@ -260,7 +262,3 @@ class AllLecturesState(SessionState):
             ).all()
 
         self.lectures = self._serialize_lectures(lectures)
-
-    def _get_route_lecture_id_param(self) -> str:
-        """Return the lecture id route parameter or an empty string."""
-        return str(self.lecture_id)

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -158,6 +158,7 @@ async def get_check_conversation_response(
 class ChatState(SessionState):
     """Handles the ChatState."""
 
+    _exercise_id: int
     messages: list[ChatMessage] = []
     current_exercise: Optional[Exercise] = None
     exercise_title: str = "No Exercise Selected"
@@ -221,7 +222,7 @@ class ChatState(SessionState):
         self._userinfo_id = userinfo.id
 
         try:
-            exercise_id = int(self.exercise_id)
+            self._exercise_id = self.get_route_param_or_error("exercise_id", dtype=int)
         except ValueError:
             yield rx.redirect(routes.NOT_FOUND)
             return
@@ -230,7 +231,7 @@ class ChatState(SessionState):
             config = get_config()
             self.token_limit = max(1, config.exercise_token_limit)
             exercise = session.exec(
-                select(Exercise).where(Exercise.id == exercise_id)
+                select(Exercise).where(Exercise.id == self._exercise_id)
             ).one_or_none()
             if exercise is None:
                 yield rx.redirect(routes.NOT_FOUND)
@@ -253,7 +254,7 @@ class ChatState(SessionState):
 
             exercise_result = session.exec(
                 select(ExerciseResult).where(
-                    ExerciseResult.exercise_id == exercise_id,
+                    ExerciseResult.exercise_id == self._exercise_id,
                     ExerciseResult.userinfo_id == self._userinfo_id,
                 )
             ).one_or_none()
@@ -313,6 +314,7 @@ class ChatState(SessionState):
 
     def on_logout(self):
         """Clears the state when the user logs out."""
+        self._exercise_id = -1
         self.messages = []
         self.current_exercise = None
         self.exercise_title = "No Exercise Selected"
@@ -343,7 +345,7 @@ class ChatState(SessionState):
         The exercise_id is used to identify the current exercise.
         It is set by the route parameter in the URL.
         """
-        return f"{routes.FINISHED_VIEW}/{self.exercise_id}"
+        return f"{routes.FINISHED_VIEW}/{self._exercise_id}"
 
     @rx.var
     def exercises_url(self) -> str:

--- a/aitutor/pages/edit_lecture/state.py
+++ b/aitutor/pages/edit_lecture/state.py
@@ -17,6 +17,8 @@ from aitutor.models import (
 )
 from aitutor.utilities.lecture_permissions import user_may_edit_lecture
 
+MAGIC_ID_NEW = "new"
+
 
 class EditLectureState(SessionState):
     """State for the edit lecture page."""
@@ -29,7 +31,7 @@ class EditLectureState(SessionState):
     check_conversation_prompt: str = ""
     unsaved_changes: bool = False
     is_new: bool = True
-    lecture_id_param: str = "new"
+    lecture_id_param: str = MAGIC_ID_NEW
     delete_confirmation_password: str = ""
 
     @rx.event
@@ -53,10 +55,12 @@ class EditLectureState(SessionState):
     def on_load(self):
         """Initialize the page state."""
         self.global_load()
-        lecture_id_param = self._get_route_lecture_id_param()
-        self.lecture_id_param = lecture_id_param
 
-        if lecture_id_param == "new":
+        self.lecture_id_param = self.get_route_param_or_default(
+            "lecture_id", default=MAGIC_ID_NEW
+        )
+
+        if self.lecture_id_param == MAGIC_ID_NEW:
             if not self._user_may_create_lecture():
                 return rx.redirect(routes.MY_LECTURES)
 
@@ -66,7 +70,7 @@ class EditLectureState(SessionState):
             return
 
         try:
-            lecture_id = int(lecture_id_param)
+            lecture_id = int(self.lecture_id_param)
         except ValueError:
             return rx.redirect(routes.NOT_FOUND)
 
@@ -82,7 +86,7 @@ class EditLectureState(SessionState):
     def on_logout(self):
         """Clear lecture-specific state on logout."""
         self._reset_form()
-        self.lecture_id_param = "new"
+        self.lecture_id_param = MAGIC_ID_NEW
         self.delete_confirmation_password = ""
 
     @rx.event
@@ -219,7 +223,7 @@ class EditLectureState(SessionState):
             session.commit()
 
         self._reset_form()
-        self.lecture_id_param = "new"
+        self.lecture_id_param = MAGIC_ID_NEW
         self.delete_confirmation_password = ""
         return [
             rx.toast.success(
@@ -267,10 +271,6 @@ class EditLectureState(SessionState):
         lecture.registration_code = self.registration_code
         lecture.lecture_information_text = self.lecture_information_text
         lecture.check_conversation_prompt = self.check_conversation_prompt
-
-    def _get_route_lecture_id_param(self) -> str:
-        """Return the lecture id route parameter or 'new' for the create page."""
-        return str(self.lecture_id or "new")
 
     def _normalized_lecture_name(self) -> str:
         """Return the trimmed lecture name used for validation and persistence."""

--- a/aitutor/pages/finished_view/state.py
+++ b/aitutor/pages/finished_view/state.py
@@ -17,6 +17,7 @@ from aitutor.utilities.lecture_permissions import user_may_view_lecture
 class FinishedViewState(SessionState):
     """The State for the finished view."""
 
+    _exercise_id: int
     messages: list[ChatMessage] = []
     current_exercise: Optional[Exercise] = None
     exercise_title: str = "No Exercise Selected"
@@ -32,7 +33,9 @@ class FinishedViewState(SessionState):
         userinfo = self.authenticated_user_info
         if userinfo:
             try:
-                exercise_id = int(self.exercise_id)
+                self._exercise_id = self.get_route_param_or_error(
+                    "exercise_id", dtype=int
+                )
             except ValueError:
                 yield rx.redirect(routes.NOT_FOUND)
                 return
@@ -45,7 +48,7 @@ class FinishedViewState(SessionState):
                     )
                     .join(ExerciseResult)
                     .where(
-                        Exercise.id == exercise_id,
+                        Exercise.id == self._exercise_id,
                         ExerciseResult.userinfo_id == userinfo.id,
                     )
                 )
@@ -78,6 +81,7 @@ class FinishedViewState(SessionState):
 
     def on_logout(self):
         """Clears the state when the user logs out."""
+        self._exercise_id = -1
         self.messages = []
         self.current_exercise = None
         self.exercise_title = "No Exercise Selected"
@@ -86,7 +90,7 @@ class FinishedViewState(SessionState):
     @rx.var
     def chat_url(self) -> str:
         """Returns the URL for the chat page."""
-        return f"{routes.CHAT}/{self.exercise_id}"
+        return f"{routes.CHAT}/{self._exercise_id}"
 
     @rx.event
     def delete_submisssion(self):

--- a/aitutor/pages/finished_view_tutor/state.py
+++ b/aitutor/pages/finished_view_tutor/state.py
@@ -27,8 +27,11 @@ class FinishedViewTutorState(SessionState):
     @state_require_role_or_permission(required_role=UserRole.STUDENT)
     def on_load(self):
         """Loads the finished exercise and user info."""
-
         self.global_load()
+
+        exercise_id = self.get_route_param_or_error("exercise_id", dtype=int)
+        url_user_id = self.get_route_param_or_error("url_user_id", dtype=int)
+
         self.current_lecture_id = None
         with rx.session() as session:
             stmt = (
@@ -39,8 +42,8 @@ class FinishedViewTutorState(SessionState):
                 .join(UserInfo)
                 .join(LocalUser)
                 .where(
-                    Exercise.id == int(self.exercise_id),
-                    LocalUser.id == int(self.url_user_id),
+                    Exercise.id == int(exercise_id),
+                    LocalUser.id == int(url_user_id),
                 )
             )
             result = session.exec(stmt).one_or_none()

--- a/aitutor/pages/lecture_exercises/state.py
+++ b/aitutor/pages/lecture_exercises/state.py
@@ -23,6 +23,7 @@ ExerciseWithResult = tuple[Exercise, Optional[ExerciseResult]]
 class LectureExercisesState(FilterMixin, SessionState):
     """State for managing exercises belonging to one lecture."""
 
+    _lecture_id: int
     exercises_with_result: list[ExerciseWithResult] = []
     open_deadline_exercises: list[ExerciseWithResult] = []
     no_deadline_exercises: list[ExerciseWithResult] = []
@@ -60,15 +61,16 @@ class LectureExercisesState(FilterMixin, SessionState):
         assert self.authenticated_user_info is not None
         self._clear_exercises()
 
-        lecture_id = self._parse_route_lecture_id()
-        if lecture_id is None:
+        try:
+            self._lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
-        if not self._user_may_view_lecture(lecture_id):
+        if not self._user_may_view_lecture(self._lecture_id):
             return rx.redirect(routes.MY_LECTURES)
 
         with rx.session() as session:
-            if session.get(Lecture, lecture_id) is None:
+            if session.get(Lecture, self._lecture_id) is None:
                 return rx.redirect(routes.NOT_FOUND)
 
         self.load_exercises()
@@ -80,22 +82,16 @@ class LectureExercisesState(FilterMixin, SessionState):
     @rx.var
     def route_lecture_id(self) -> str:
         """Return the lecture id route parameter for lecture-specific navigation."""
-        return str(self.lecture_id)
+        return str(self._lecture_id)
 
     def _clear_exercises(self):
         """Clear loaded exercise lists."""
+        self._lecture_id = -1
         self.exercises_with_result = []
         self.open_deadline_exercises = []
         self.no_deadline_exercises = []
         self.closed_deadline_exercises = []
         self.time_left_strings = {}
-
-    def _parse_route_lecture_id(self) -> int | None:
-        """Return the numeric lecture id from the route, or None if invalid."""
-        try:
-            return int(self.lecture_id)
-        except ValueError:
-            return None
 
     def _user_may_view_lecture(self, lecture_id: int) -> bool:
         """Check whether the current user may view this lecture."""
@@ -166,8 +162,7 @@ class LectureExercisesState(FilterMixin, SessionState):
         """
         Get exercises from db based on the current search values and the user role.
         """
-        lecture_id = self._parse_route_lecture_id()
-        if lecture_id is None:
+        if self._lecture_id is None:
             self._clear_exercises()
             return
 
@@ -185,7 +180,7 @@ class LectureExercisesState(FilterMixin, SessionState):
                     ),
                     isouter=True,
                 )
-                .where(Exercise.lecture_id == lecture_id)
+                .where(Exercise.lecture_id == self._lecture_id)
             )
 
             # Don't load hidden exercises for students

--- a/aitutor/pages/lecture_manage_exercises/state.py
+++ b/aitutor/pages/lecture_manage_exercises/state.py
@@ -140,8 +140,8 @@ class LectureManageExercisesState(FilterMixin, SessionState):
         self.current_lecture_id = None
 
         try:
-            lecture_id = int(self.lecture_id)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_manage_lecture(lecture_id):

--- a/aitutor/pages/lecture_members/state.py
+++ b/aitutor/pages/lecture_members/state.py
@@ -77,8 +77,8 @@ class LectureMembersState(SessionState):
         self._reset_page_state()
 
         try:
-            lecture_id = int(self.lecture_id)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_view_lecture(lecture_id):

--- a/aitutor/pages/lecture_overview/state.py
+++ b/aitutor/pages/lecture_overview/state.py
@@ -31,10 +31,9 @@ class LectureOverviewState(SessionState):
         self.global_load()
         self._reset_lecture_state()
 
-        lecture_id_param = self._get_route_lecture_id_param()
         try:
-            lecture_id = int(lecture_id_param)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_view_lecture(lecture_id):
@@ -139,10 +138,6 @@ class LectureOverviewState(SessionState):
 
         title, deadline = min(tasks, key=lambda t: t[1])
         return f"{title} – {deadline.strftime('%d.%m.%Y, %H:%M')}"
-
-    def _get_route_lecture_id_param(self) -> str:
-        """Return the lecture id route parameter."""
-        return str(self.lecture_id)
 
     def _user_may_view_lecture(self, lecture_id: int) -> bool:
         """Check whether the current user may open this lecture."""

--- a/aitutor/pages/lecture_report_view/state.py
+++ b/aitutor/pages/lecture_report_view/state.py
@@ -18,6 +18,7 @@ from aitutor.utilities.lecture_permissions import user_may_view_lecture_submissi
 class LectureReportViewState(SessionState):
     """State for viewing a specific report in a lecture context."""
 
+    _report_id: int
     current_lecture_id: int | None = None
     reports_route: str = routes.MY_LECTURES
     report_text: str = ""
@@ -36,8 +37,9 @@ class LectureReportViewState(SessionState):
         self._clear_report_data()
 
         try:
-            lecture_id = int(self.lecture_id)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+            self._report_id = self.get_route_param_or_error("report_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_view_report(lecture_id):
@@ -53,6 +55,7 @@ class LectureReportViewState(SessionState):
 
     def on_logout(self):
         """Clear state when user logs out."""
+        self._report_id = -1
         self.current_lecture_id = None
         self.reports_route = routes.MY_LECTURES
         self._clear_report_data()
@@ -69,7 +72,7 @@ class LectureReportViewState(SessionState):
             report = session.exec(
                 select(Report)
                 .where(
-                    Report.id == int(self.report_id),
+                    Report.id == self._report_id,
                     Report.lecture_id == self.current_lecture_id,
                 )
                 .options(
@@ -119,7 +122,7 @@ class LectureReportViewState(SessionState):
         with rx.session() as session:
             report = session.exec(
                 select(Report).where(
-                    Report.id == int(self.report_id),
+                    Report.id == self._report_id,
                     Report.lecture_id == self.current_lecture_id,
                 )
             ).first()

--- a/aitutor/pages/lecture_reports/state.py
+++ b/aitutor/pages/lecture_reports/state.py
@@ -59,8 +59,8 @@ class LectureReportsState(FilterMixin, SessionState):
         self.table_rows = []
 
         try:
-            lecture_id = int(self.lecture_id)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_view_reports(lecture_id):

--- a/aitutor/pages/lecture_submissions/state.py
+++ b/aitutor/pages/lecture_submissions/state.py
@@ -61,8 +61,8 @@ class LectureSubmissionsState(FilterMixin, SessionState):
         self.table_rows = []
 
         try:
-            lecture_id = int(self.lecture_id)
-        except ValueError:
+            lecture_id = self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return rx.redirect(routes.NOT_FOUND)
 
         if not self._user_may_view_submissions(lecture_id):

--- a/aitutor/pages/navbar_specific_lecture.py
+++ b/aitutor/pages/navbar_specific_lecture.py
@@ -52,8 +52,8 @@ class SpecificLectureNavbarState(SessionState):
             return None
 
         try:
-            return int(self.lecture_id)
-        except ValueError:
+            return self.get_route_param_or_error("lecture_id", dtype=int)
+        except Exception:
             return None
 
 

--- a/aitutor/pages/report_view/state.py
+++ b/aitutor/pages/report_view/state.py
@@ -13,6 +13,7 @@ from aitutor.pages.chat.state import ChatMessage, Role
 class ReportViewState(SessionState):
     """State for viewing a specific report."""
 
+    _report_id: int
     report_text: str = ""
     looked_at: bool = False
     exercise_title: str | None = None
@@ -24,10 +25,13 @@ class ReportViewState(SessionState):
     def on_load(self):
         """Load report details when page opens."""
         self.global_load()
+
+        self._report_id = self.get_route_param_or_error("report_id", dtype=int)
         self.load_report()
 
     def on_logout(self):
         """Clear state when user logs out."""
+        self._report_id = -1
         self.report_text = ""
         self.looked_at = False
         self.exercise_title = ""
@@ -41,7 +45,7 @@ class ReportViewState(SessionState):
             # Load report with all needed relationships
             report = session.exec(
                 select(Report)
-                .where(Report.id == int(self.report_id))
+                .where(Report.id == self._report_id)
                 .options(
                     selectinload(Report.exercise),  # type: ignore
                     selectinload(Report.userinfo).selectinload(UserInfo.local_user),  # type: ignore
@@ -84,7 +88,7 @@ class ReportViewState(SessionState):
         """Toggle the looked_at status of the report."""
         with rx.session() as session:
             report = session.exec(
-                select(Report).where(Report.id == int(self.report_id))
+                select(Report).where(Report.id == self._report_id)
             ).first()
 
             if report:


### PR DESCRIPTION
Instead of using reflex's magically created state class attributes, access route parameters via some helper functions. This makes the code easier to understand and is also more type-checker friendly (pyright was complaining about all those undefined attributes).

I added two methods:
- `get_route_param_or_default`: For cases where the parameter is optional and a default value is needed.
- `get_route_param_or_error`: For cases where the parameter is required (raises an error if not found).

I tried to keep changes to the other files minimal but did a little bit of restructuring in some cases to make the code simpler.

@Andrewtuebingen This resolves the pyright errors in #348.  Do you think this approach makes sense?


**Do not merge before:**
- #348 