### PR TITLE
Send emails via SMTP

### DIFF
--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -11,9 +11,8 @@ from aitutor.models import UserInfo
 
 def public_base_url() -> str:
     """Public base URL used for links in account emails."""
-    return cast(
-        str, config("AITUTOR_PUBLIC_URL", default="http://localhost:3000", cast=str)
-    ).rstrip("/")
+    domain = cast(str, config("DOMAIN", default="localhost", cast=str)).strip()
+    return f"https://{domain}".rstrip("/")
 
 
 def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -3,27 +3,15 @@
 from typing import cast
 
 from decouple import config
-from reflex_local_auth.user import LocalUser
 
 from aitutor.mail import send_text_email
-from aitutor.models import Language, UserInfo
+from aitutor.models import Language
 
 
 def public_base_url() -> str:
     """Public base URL used for links in account emails."""
     domain = cast(str, config("DOMAIN", default="localhost", cast=str)).strip()
     return f"https://{domain}".rstrip("/")
-
-
-def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
-    """Send a welcome email for a newly registered account."""
-    if local_user.id is None:
-        raise ValueError("Cannot send welcome email before user is persisted.")
-    send_signup_welcome_email(
-        to_email=user_info.email,
-        username=local_user.username,
-        language=user_info.language,
-    )
 
 
 def send_signup_welcome_email(

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -1,17 +1,13 @@
 """Account welcome email helpers."""
 
-from typing import cast
-
-from decouple import config
-
+from aitutor.app_settings import get_settings
 from aitutor.mail import send_text_email
 from aitutor.models import Language
 
 
 def public_base_url() -> str:
     """Public base URL used for links in account emails."""
-    domain = cast(str, config("DOMAIN", default="localhost", cast=str)).strip()
-    return f"https://{domain}".rstrip("/")
+    return f"https://{get_settings().domain}".rstrip("/")
 
 
 def send_signup_welcome_email(

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -1,0 +1,34 @@
+"""Account welcome email helpers."""
+
+from typing import cast
+
+from decouple import config
+from reflex_local_auth.user import LocalUser
+
+from aitutor.mail import send_text_email
+from aitutor.models import UserInfo
+
+
+def public_base_url() -> str:
+    """Public base URL used for links in account emails."""
+    return cast(
+        str, config("AITUTOR_PUBLIC_URL", default="http://localhost:3000", cast=str)
+    ).rstrip("/")
+
+
+def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
+    """Send a welcome email for a newly registered account."""
+    from aitutor.language_state import BackendTranslations as BT
+
+    if local_user.id is None:
+        raise ValueError("Cannot send welcome email before user is persisted.")
+    login_url = f"{public_base_url()}/login"
+    send_text_email(
+        to_email=user_info.email,
+        subject=BT.signup_welcome_subject(user_info.language),
+        body=BT.signup_welcome_body(
+            user_info.language,
+            username=local_user.username,
+            login_url=login_url,
+        ),
+    )

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -6,7 +6,7 @@ from decouple import config
 from reflex_local_auth.user import LocalUser
 
 from aitutor.mail import send_text_email
-from aitutor.models import UserInfo
+from aitutor.models import Language, UserInfo
 
 
 def public_base_url() -> str:
@@ -17,17 +17,27 @@ def public_base_url() -> str:
 
 def send_signup_welcome(*, local_user: LocalUser, user_info: UserInfo) -> None:
     """Send a welcome email for a newly registered account."""
-    from aitutor.language_state import BackendTranslations as BT
-
     if local_user.id is None:
         raise ValueError("Cannot send welcome email before user is persisted.")
-    login_url = f"{public_base_url()}/login"
-    send_text_email(
+    send_signup_welcome_email(
         to_email=user_info.email,
-        subject=BT.signup_welcome_subject(user_info.language),
+        username=local_user.username,
+        language=user_info.language,
+    )
+
+
+def send_signup_welcome_email(
+    *, to_email: str, username: str, language: Language
+) -> None:
+    """Send a welcome email using plain account values."""
+    from aitutor.language_state import BackendTranslations as BT
+
+    send_text_email(
+        to_email=to_email,
+        subject=BT.signup_welcome_subject(language),
         body=BT.signup_welcome_body(
-            user_info.language,
-            username=local_user.username,
-            login_url=login_url,
+            language,
+            username=username,
+            login_url=f"{public_base_url()}/login",
         ),
     )

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -199,6 +199,12 @@ def initialize():
     if settings.openai_base_url:
         print(f"Using OPENAI_BASE_URL={settings.openai_base_url}")
 
+    if not settings.SMTP:
+        cprint(
+            "Warning: SMTP is not configured. Emails will not be sent.",
+            fg="yellow",
+        )
+
     create_default_users()
 
     with rx.session() as session:

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -13,6 +13,7 @@ from aitutor import pages
 from aitutor.app_settings import get_settings
 from aitutor.config import add_configprompts_to_db, get_config, initialize_config_db
 from aitutor.models import Prompt
+from aitutor.utilities.cprint import cprint
 from aitutor.utilities.create_default_users import create_default_users
 
 app = rx.App(
@@ -177,7 +178,7 @@ app.add_page(pages.privacy_notice_page, route=routes.PRIVACY_NOTICE)
 def initialize():
     """Initialization steps that are run once when the app starts."""
 
-    print("Executing initialization tasks:")
+    print("Executing initialization tasks")
 
     # ensure there is a config row in the database
     initialize_config_db()
@@ -186,13 +187,13 @@ def initialize():
     try:
         _ = get_config()
     except Exception as e:
-        print("\033[91m" + f"Error loading config: {e}" + "\033[0m")
+        cprint(f"Error loading config: {e}", fg="white", bg="red")
         sys.exit(1)
 
     try:
         settings = get_settings()
     except ValueError as e:
-        print("\033[91m" + str(e) + "\033[0m")
+        cprint(f"Error loading settings: {e}", fg="white", bg="red")
         sys.exit(1)
 
     if settings.openai_base_url:
@@ -208,7 +209,7 @@ def initialize():
             print("No prompts found in the database. Adding default prompts...")
             add_configprompts_to_db()
 
-    print("\033[92m" + "Initialization tasks completed." + "\033[0m")
+    cprint("Initialization tasks completed.", fg="green")
 
 
 app.register_lifespan_task(initialize)

--- a/aitutor/app_settings.py
+++ b/aitutor/app_settings.py
@@ -25,18 +25,24 @@ class AppSettings(BaseSettings):
     domain: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
         default="localhost", validation_alias="DOMAIN"
     )
-    smtp_host: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
-        default="", validation_alias="SMTP_HOST"
+    smtp_host: Annotated[str, StringConstraints(strip_whitespace=True)] | None = Field(
+        default=None, validation_alias="SMTP_HOST"
     )
     smtp_port: int | None = Field(default=None, validation_alias="SMTP_PORT")
-    smtp_from_email: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
-        default="", validation_alias="SMTP_FROM_EMAIL"
+    smtp_from_email: Annotated[str, StringConstraints(strip_whitespace=True)] | None = (
+        Field(
+            default=None,
+            validation_alias="SMTP_FROM_EMAIL",
+        )
     )
-    smtp_username: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
-        default="", validation_alias="SMTP_USERNAME"
+    smtp_username: Annotated[str, StringConstraints(strip_whitespace=True)] | None = (
+        Field(
+            default=None,
+            validation_alias="SMTP_USERNAME",
+        )
     )
-    smtp_password: str = Field(default="", validation_alias="SMTP_PASSWORD")
-    smtp_use_tls: bool | None = Field(default=None, validation_alias="SMTP_USE_TLS")
+    smtp_password: str | None = Field(default=None, validation_alias="SMTP_PASSWORD")
+    smtp_use_tls: bool = Field(default=False, validation_alias="SMTP_USE_TLS")
     smtp_use_ssl: bool = Field(default=False, validation_alias="SMTP_USE_SSL")
     smtp_timeout: int = Field(default=10, validation_alias="SMTP_TIMEOUT")
 

--- a/aitutor/app_settings.py
+++ b/aitutor/app_settings.py
@@ -22,6 +22,23 @@ class AppSettings(BaseSettings):
     openai_base_url: str | None = Field(
         default=None, validation_alias="OPENAI_BASE_URL"
     )
+    domain: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+        default="localhost", validation_alias="DOMAIN"
+    )
+    smtp_host: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+        default="", validation_alias="SMTP_HOST"
+    )
+    smtp_port: int | None = Field(default=None, validation_alias="SMTP_PORT")
+    smtp_from_email: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+        default="", validation_alias="SMTP_FROM_EMAIL"
+    )
+    smtp_username: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+        default="", validation_alias="SMTP_USERNAME"
+    )
+    smtp_password: str = Field(default="", validation_alias="SMTP_PASSWORD")
+    smtp_use_tls: bool | None = Field(default=None, validation_alias="SMTP_USE_TLS")
+    smtp_use_ssl: bool = Field(default=False, validation_alias="SMTP_USE_SSL")
+    smtp_timeout: int = Field(default=10, validation_alias="SMTP_TIMEOUT")
 
     @field_validator("openai_base_url", mode="before")
     @classmethod

--- a/aitutor/app_settings.py
+++ b/aitutor/app_settings.py
@@ -1,10 +1,58 @@
 """Environment-backed application settings."""
 
+from __future__ import annotations
+
 from functools import lru_cache
 from typing import Annotated
 
-from pydantic import Field, StringConstraints, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SmtpSettings(BaseModel):
+    """Settings for SMTP email sending."""
+
+    HOST: str = Field(validation_alias="HOST")
+    PORT: int = Field(validation_alias="PORT")
+    FROM_EMAIL: str = Field(validation_alias="FROM_EMAIL")
+
+    USERNAME: str | None = Field(default=None, validation_alias="USERNAME")
+    PASSWORD: str | None = Field(default=None, validation_alias="PASSWORD")
+
+    USE_TLS: bool = Field(default=False, validation_alias="USE_TLS")
+    USE_SSL: bool = Field(default=False, validation_alias="USE_SSL")
+
+    TIMEOUT: int = Field(default=10, validation_alias="TIMEOUT")
+
+    @field_validator("PORT", "TIMEOUT", mode="after")
+    @classmethod
+    def _validate_greater_than_zero(cls, value: int) -> int:
+        """Validate that the value is greater than zero."""
+        if value <= 0:
+            raise ValueError("must be greater than zero")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_tls_ssl(self) -> SmtpSettings:
+        """Validate that TLS and SSL are not both enabled."""
+        if self.USE_TLS and self.USE_SSL:
+            raise ValueError("SMTP_USE_TLS and SMTP_USE_SSL cannot both be enabled.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_username_password(self) -> SmtpSettings:
+        """Validate that username and password are both set or both unset."""
+        if bool(self.USERNAME) != bool(self.PASSWORD):
+            raise ValueError(
+                "SMTP_USERNAME and SMTP_PASSWORD must be configured together."
+            )
+        return self
 
 
 class AppSettings(BaseSettings):
@@ -13,6 +61,8 @@ class AppSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        env_nested_delimiter="_",
+        env_nested_max_split=1,
         extra="ignore",
     )
 
@@ -25,26 +75,8 @@ class AppSettings(BaseSettings):
     domain: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
         default="localhost", validation_alias="DOMAIN"
     )
-    smtp_host: Annotated[str, StringConstraints(strip_whitespace=True)] | None = Field(
-        default=None, validation_alias="SMTP_HOST"
-    )
-    smtp_port: int | None = Field(default=None, validation_alias="SMTP_PORT")
-    smtp_from_email: Annotated[str, StringConstraints(strip_whitespace=True)] | None = (
-        Field(
-            default=None,
-            validation_alias="SMTP_FROM_EMAIL",
-        )
-    )
-    smtp_username: Annotated[str, StringConstraints(strip_whitespace=True)] | None = (
-        Field(
-            default=None,
-            validation_alias="SMTP_USERNAME",
-        )
-    )
-    smtp_password: str | None = Field(default=None, validation_alias="SMTP_PASSWORD")
-    smtp_use_tls: bool = Field(default=False, validation_alias="SMTP_USE_TLS")
-    smtp_use_ssl: bool = Field(default=False, validation_alias="SMTP_USE_SSL")
-    smtp_timeout: int = Field(default=10, validation_alias="SMTP_TIMEOUT")
+
+    SMTP: SmtpSettings | None = None
 
     @field_validator("openai_base_url", mode="before")
     @classmethod

--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -9,7 +9,6 @@ import reflex_local_auth
 from sqlmodel import select
 
 import aitutor.routes as routes
-from aitutor import pages
 from aitutor.models import GlobalPermission, Language, Permission, UserInfo, UserRole
 
 
@@ -75,6 +74,8 @@ class SessionState(reflex_local_auth.LocalAuthState):
         """
         Handles the logout process for the authenticated user.
         """
+        from aitutor import pages
+
         states = [
             pages.AllLecturesState,
             pages.ChatState,

--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -24,6 +24,16 @@ def translate(language: Language, *, de: str, en: str) -> str:
             return en
 
 
+def language_from_value(value: object) -> Language:
+    """Parse a language value from form data, falling back to English."""
+    if isinstance(value, Language):
+        return value
+    try:
+        return Language(str(value))
+    except ValueError:
+        return Language.EN
+
+
 class LanguageState(SessionState):
     """State that returns all strings in the current language."""
 
@@ -850,6 +860,20 @@ class LanguageState(SessionState):
         )
 
     @rx.var
+    def successful_registration_with_email(self) -> str:
+        return self.translate(
+            de="Registrierung erfolgreich. Wir haben Ihnen eine Willkommens-E-Mail gesendet.",
+            en="Registration successful. We sent you a welcome email.",
+        )
+
+    @rx.var
+    def successful_registration_email_failed(self) -> str:
+        return self.translate(
+            de="Registrierung erfolgreich, aber die Willkommens-E-Mail konnte nicht gesendet werden.",
+            en="Registration successful, but the welcome email could not be sent.",
+        )
+
+    @rx.var
     def registration_code(self) -> str:
         """Registration Code string"""
         return self.translate(de="Registrierungscode", en="Registration code")
@@ -1636,6 +1660,37 @@ class BackendTranslations:
             language,
             de="Fehler: Das eingegebene Passwort ist falsch.",
             en="Error: The entered password is incorrect.",
+        )
+
+    # Account email flows ---------------------------------------------------------------
+    @staticmethod
+    def signup_welcome_subject(language: Language) -> str:
+        return translate(
+            language,
+            de="Willkommen bei AI Tutor",
+            en="Welcome to AI Tutor",
+        )
+
+    @staticmethod
+    def signup_welcome_body(
+        language: Language, *, username: str, login_url: str
+    ) -> str:
+        return translate(
+            language,
+            de=(
+                f"Hallo {username},\n\n"
+                "Ihr AI Tutor Konto wurde erfolgreich erstellt.\n\n"
+                f"Benutzername: {username}\n\n"
+                f"Sie können sich hier anmelden:\n{login_url}\n\n"
+                "Falls Sie dieses Konto nicht erstellt haben, kontaktieren Sie bitte das AI Tutor Team."
+            ),
+            en=(
+                f"Hello {username},\n\n"
+                "Your AI Tutor account has been created successfully.\n\n"
+                f"Username: {username}\n\n"
+                f"You can log in here:\n{login_url}\n\n"
+                "If you did not create this account, please contact the AI Tutor team."
+            ),
         )
 
     # ManageExercisesState -------------------------------------------------------------

--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -1677,20 +1677,34 @@ class BackendTranslations:
     ) -> str:
         return translate(
             language,
-            de=(
-                f"Hallo {username},\n\n"
-                "Ihr AI Tutor Konto wurde erfolgreich erstellt.\n\n"
-                f"Benutzername: {username}\n\n"
-                f"Sie können sich hier anmelden:\n{login_url}\n\n"
-                "Falls Sie dieses Konto nicht erstellt haben, kontaktieren Sie bitte das AI Tutor Team."
-            ),
-            en=(
-                f"Hello {username},\n\n"
-                "Your AI Tutor account has been created successfully.\n\n"
-                f"Username: {username}\n\n"
-                f"You can log in here:\n{login_url}\n\n"
-                "If you did not create this account, please contact the AI Tutor team."
-            ),
+            de=textwrap.dedent(
+                f"""
+                Hallo {username},
+
+                Ihr AI Tutor Konto wurde erfolgreich erstellt.
+
+                Benutzername: {username}
+
+                Sie können sich hier anmelden:
+                {login_url}
+
+                Falls Sie dieses Konto nicht erstellt haben, kontaktieren Sie bitte das AI Tutor Team.
+                """
+            ).lstrip(),
+            en=textwrap.dedent(
+                f"""
+                Hello {username},
+
+                Your AI Tutor account has been created successfully.
+
+                Username: {username}
+
+                You can log in here:
+                {login_url}
+
+                If you did not create this account, please contact the AI Tutor team.
+                """
+            ).lstrip(),
         )
 
     # ManageExercisesState -------------------------------------------------------------

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -37,11 +37,7 @@ class SmtpSettings:
         default_port = 465 if use_ssl else 587
         settings = cls(
             host=app_settings.smtp_host or "",
-            port=(
-                app_settings.smtp_port
-                if app_settings.smtp_port is not None
-                else default_port
-            ),
+            port=app_settings.smtp_port or default_port,
             from_email=app_settings.smtp_from_email or "",
             username=app_settings.smtp_username or "",
             password=app_settings.smtp_password or "",

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -34,9 +34,14 @@ class SmtpSettings:
         """Load and validate SMTP settings from environment variables."""
         app_settings = get_settings()
         use_ssl = app_settings.smtp_use_ssl
+        default_port = 465 if use_ssl else 587
         settings = cls(
             host=app_settings.smtp_host,
-            port=app_settings.smtp_port or (465 if use_ssl else 587),
+            port=(
+                app_settings.smtp_port
+                if app_settings.smtp_port is not None
+                else default_port
+            ),
             from_email=app_settings.smtp_from_email,
             username=app_settings.smtp_username,
             password=app_settings.smtp_password,

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -1,0 +1,138 @@
+"""SMTP email helpers for account-related messages."""
+
+from dataclasses import dataclass
+from email.message import EmailMessage
+from smtplib import SMTP, SMTP_SSL, SMTPException
+from typing import Any, Callable, cast
+
+from decouple import config
+
+
+class EmailConfigurationError(RuntimeError):
+    """Raised when email sending is requested without valid SMTP settings."""
+
+
+class EmailDeliveryError(RuntimeError):
+    """Raised when an email could not be delivered through SMTP."""
+
+
+@dataclass(frozen=True)
+class SmtpSettings:
+    """Runtime SMTP settings loaded from the deployment environment."""
+
+    host: str
+    port: int
+    from_email: str
+    username: str = ""
+    password: str = ""
+    use_tls: bool = True
+    use_ssl: bool = False
+    timeout: int = 10
+
+    @classmethod
+    def from_env(cls) -> "SmtpSettings":
+        """Load and validate SMTP settings from environment variables."""
+        use_ssl = cast(bool, config("SMTP_USE_SSL", default=False, cast=bool))
+        settings = cls(
+            host=cast(str, config("SMTP_HOST", default="", cast=str)).strip(),
+            port=cast(
+                int, config("SMTP_PORT", default=465 if use_ssl else 587, cast=int)
+            ),
+            from_email=cast(
+                str, config("SMTP_FROM_EMAIL", default="", cast=str)
+            ).strip(),
+            username=cast(str, config("SMTP_USERNAME", default="", cast=str)).strip(),
+            password=cast(str, config("SMTP_PASSWORD", default="", cast=str)),
+            use_tls=cast(bool, config("SMTP_USE_TLS", default=not use_ssl, cast=bool)),
+            use_ssl=use_ssl,
+            timeout=cast(int, config("SMTP_TIMEOUT", default=10, cast=int)),
+        )
+        settings.validate()
+        return settings
+
+    def validate(self) -> None:
+        """Validate settings needed for SMTP delivery."""
+        if not self.host:
+            raise EmailConfigurationError("SMTP_HOST is required to send email.")
+        if not self.from_email:
+            raise EmailConfigurationError("SMTP_FROM_EMAIL is required to send email.")
+        if self.port <= 0:
+            raise EmailConfigurationError("SMTP_PORT must be greater than 0.")
+        if self.timeout <= 0:
+            raise EmailConfigurationError("SMTP_TIMEOUT must be greater than 0.")
+        if self.use_tls and self.use_ssl:
+            raise EmailConfigurationError(
+                "SMTP_USE_TLS and SMTP_USE_SSL cannot both be enabled."
+            )
+        if bool(self.username) != bool(self.password):
+            raise EmailConfigurationError(
+                "SMTP_USERNAME and SMTP_PASSWORD must be configured together."
+            )
+
+    @property
+    def uses_authentication(self) -> bool:
+        """Whether SMTP username/password authentication is configured."""
+        return bool(self.username and self.password)
+
+
+def build_text_email(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    settings: SmtpSettings | None = None,
+) -> EmailMessage:
+    """Build a plain text email message."""
+    active_settings = settings or SmtpSettings.from_env()
+    message = EmailMessage()
+    message["From"] = active_settings.from_email
+    message["To"] = to_email
+    message["Subject"] = subject
+    message.set_content(body)
+    return message
+
+
+def send_text_email(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    settings: SmtpSettings | None = None,
+) -> None:
+    """Build and send a plain text email message."""
+    active_settings = settings or SmtpSettings.from_env()
+    send_email(
+        build_text_email(
+            to_email=to_email,
+            subject=subject,
+            body=body,
+            settings=active_settings,
+        ),
+        settings=active_settings,
+    )
+
+
+def send_email(
+    message: EmailMessage,
+    *,
+    settings: SmtpSettings | None = None,
+    smtp_client_cls: Callable[..., Any] | None = None,
+) -> None:
+    """Send an email message through the configured SMTP server."""
+    active_settings = settings or SmtpSettings.from_env()
+    active_settings.validate()
+    client_cls = smtp_client_cls or (SMTP_SSL if active_settings.use_ssl else SMTP)
+
+    try:
+        with client_cls(
+            active_settings.host,
+            active_settings.port,
+            timeout=active_settings.timeout,
+        ) as smtp:
+            if active_settings.use_tls:
+                smtp.starttls()
+            if active_settings.uses_authentication:
+                smtp.login(active_settings.username, active_settings.password)
+            smtp.send_message(message)
+    except (OSError, SMTPException) as exc:
+        raise EmailDeliveryError("Failed to send email via SMTP.") from exc

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -3,9 +3,9 @@
 from dataclasses import dataclass
 from email.message import EmailMessage
 from smtplib import SMTP, SMTP_SSL, SMTPException
-from typing import Any, Callable, cast
+from typing import Any, Callable
 
-from decouple import config
+from aitutor.app_settings import get_settings
 
 
 class EmailConfigurationError(RuntimeError):
@@ -32,20 +32,21 @@ class SmtpSettings:
     @classmethod
     def from_env(cls) -> "SmtpSettings":
         """Load and validate SMTP settings from environment variables."""
-        use_ssl = cast(bool, config("SMTP_USE_SSL", default=False, cast=bool))
+        app_settings = get_settings()
+        use_ssl = app_settings.smtp_use_ssl
         settings = cls(
-            host=cast(str, config("SMTP_HOST", default="", cast=str)).strip(),
-            port=cast(
-                int, config("SMTP_PORT", default=465 if use_ssl else 587, cast=int)
+            host=app_settings.smtp_host,
+            port=app_settings.smtp_port or (465 if use_ssl else 587),
+            from_email=app_settings.smtp_from_email,
+            username=app_settings.smtp_username,
+            password=app_settings.smtp_password,
+            use_tls=(
+                not use_ssl
+                if app_settings.smtp_use_tls is None
+                else app_settings.smtp_use_tls
             ),
-            from_email=cast(
-                str, config("SMTP_FROM_EMAIL", default="", cast=str)
-            ).strip(),
-            username=cast(str, config("SMTP_USERNAME", default="", cast=str)).strip(),
-            password=cast(str, config("SMTP_PASSWORD", default="", cast=str)),
-            use_tls=cast(bool, config("SMTP_USE_TLS", default=not use_ssl, cast=bool)),
             use_ssl=use_ssl,
-            timeout=cast(int, config("SMTP_TIMEOUT", default=10, cast=int)),
+            timeout=app_settings.smtp_timeout,
         )
         settings.validate()
         return settings

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -25,7 +25,7 @@ class SmtpSettings:
     from_email: str
     username: str = ""
     password: str = ""
-    use_tls: bool = True
+    use_tls: bool = False
     use_ssl: bool = False
     timeout: int = 10
 
@@ -36,20 +36,16 @@ class SmtpSettings:
         use_ssl = app_settings.smtp_use_ssl
         default_port = 465 if use_ssl else 587
         settings = cls(
-            host=app_settings.smtp_host,
+            host=app_settings.smtp_host or "",
             port=(
                 app_settings.smtp_port
                 if app_settings.smtp_port is not None
                 else default_port
             ),
-            from_email=app_settings.smtp_from_email,
-            username=app_settings.smtp_username,
-            password=app_settings.smtp_password,
-            use_tls=(
-                not use_ssl
-                if app_settings.smtp_use_tls is None
-                else app_settings.smtp_use_tls
-            ),
+            from_email=app_settings.smtp_from_email or "",
+            username=app_settings.smtp_username or "",
+            password=app_settings.smtp_password or "",
+            use_tls=app_settings.smtp_use_tls,
             use_ssl=use_ssl,
             timeout=app_settings.smtp_timeout,
         )

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -131,6 +131,7 @@ def send_email(
         ) as smtp:
             if active_settings.use_tls:
                 smtp.starttls()
+                smtp.ehlo()
             if active_settings.uses_authentication:
                 smtp.login(active_settings.username, active_settings.password)
             smtp.send_message(message)

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -67,7 +67,6 @@ class SmtpSettings:
                 "SMTP_USERNAME and SMTP_PASSWORD must be configured together."
             )
 
-    @property
     def uses_authentication(self) -> bool:
         """Whether SMTP username/password authentication is configured."""
         return bool(self.username and self.password)
@@ -130,7 +129,7 @@ def send_email(
             if active_settings.use_tls:
                 smtp.starttls()
                 smtp.ehlo()
-            if active_settings.uses_authentication:
+            if active_settings.uses_authentication():
                 smtp.login(active_settings.username, active_settings.password)
             smtp.send_message(message)
     except (OSError, SMTPException) as exc:

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -35,14 +35,31 @@ def send_text_email(
     settings: SmtpSettings | None = None,
 ) -> None:
     """Build and send a plain text email message."""
-    settings = settings or get_settings().smtp
+    settings = settings or get_settings().SMTP
+
+    # settings may be None, which means no SMTP is configured.  In this case, simply
+    # print the email to stdout for debugging.
+
+    from_email = settings.FROM_EMAIL if settings else "Testing <test@localhost>"
     mail = build_text_email(
-        from_email=settings.from_email,
+        from_email=from_email,
         to_email=to_email,
         subject=subject,
         body=body,
     )
-    send_email(mail, settings=settings)
+    if settings:
+        send_email(mail, settings=settings)
+    else:
+        print_mail(mail)
+
+
+def print_mail(
+    message: EmailMessage,
+) -> None:
+    """Print the email message to stdout for debugging."""
+    print("=== Email Message ===")
+    print(message)
+    print("=====================")
 
 
 def send_email(

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -74,15 +74,14 @@ class SmtpSettings:
 
 def build_text_email(
     *,
+    from_email: str,
     to_email: str,
     subject: str,
     body: str,
-    settings: SmtpSettings | None = None,
 ) -> EmailMessage:
     """Build a plain text email message."""
-    active_settings = settings or SmtpSettings.from_env()
     message = EmailMessage()
-    message["From"] = active_settings.from_email
+    message["From"] = from_email
     message["To"] = to_email
     message["Subject"] = subject
     message.set_content(body)
@@ -100,10 +99,10 @@ def send_text_email(
     active_settings = settings or SmtpSettings.from_env()
     send_email(
         build_text_email(
+            from_email=active_settings.from_email,
             to_email=to_email,
             subject=subject,
             body=body,
-            settings=active_settings,
         ),
         settings=active_settings,
     )

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -1,75 +1,14 @@
 """SMTP email helpers for account-related messages."""
 
-from dataclasses import dataclass
 from email.message import EmailMessage
 from smtplib import SMTP, SMTP_SSL, SMTPException
 from typing import Any, Callable
 
-from aitutor.app_settings import get_settings
-
-
-class EmailConfigurationError(RuntimeError):
-    """Raised when email sending is requested without valid SMTP settings."""
+from aitutor.app_settings import SmtpSettings, get_settings
 
 
 class EmailDeliveryError(RuntimeError):
     """Raised when an email could not be delivered through SMTP."""
-
-
-@dataclass(frozen=True)
-class SmtpSettings:
-    """Runtime SMTP settings loaded from the deployment environment."""
-
-    host: str
-    port: int
-    from_email: str
-    username: str = ""
-    password: str = ""
-    use_tls: bool = False
-    use_ssl: bool = False
-    timeout: int = 10
-
-    @classmethod
-    def from_env(cls) -> "SmtpSettings":
-        """Load and validate SMTP settings from environment variables."""
-        app_settings = get_settings()
-        use_ssl = app_settings.smtp_use_ssl
-        default_port = 465 if use_ssl else 587
-        settings = cls(
-            host=app_settings.smtp_host or "",
-            port=app_settings.smtp_port or default_port,
-            from_email=app_settings.smtp_from_email or "",
-            username=app_settings.smtp_username or "",
-            password=app_settings.smtp_password or "",
-            use_tls=app_settings.smtp_use_tls,
-            use_ssl=use_ssl,
-            timeout=app_settings.smtp_timeout,
-        )
-        settings.validate()
-        return settings
-
-    def validate(self) -> None:
-        """Validate settings needed for SMTP delivery."""
-        if not self.host:
-            raise EmailConfigurationError("SMTP_HOST is required to send email.")
-        if not self.from_email:
-            raise EmailConfigurationError("SMTP_FROM_EMAIL is required to send email.")
-        if self.port <= 0:
-            raise EmailConfigurationError("SMTP_PORT must be greater than 0.")
-        if self.timeout <= 0:
-            raise EmailConfigurationError("SMTP_TIMEOUT must be greater than 0.")
-        if self.use_tls and self.use_ssl:
-            raise EmailConfigurationError(
-                "SMTP_USE_TLS and SMTP_USE_SSL cannot both be enabled."
-            )
-        if bool(self.username) != bool(self.password):
-            raise EmailConfigurationError(
-                "SMTP_USERNAME and SMTP_PASSWORD must be configured together."
-            )
-
-    def uses_authentication(self) -> bool:
-        """Whether SMTP username/password authentication is configured."""
-        return bool(self.username and self.password)
 
 
 def build_text_email(
@@ -96,40 +35,36 @@ def send_text_email(
     settings: SmtpSettings | None = None,
 ) -> None:
     """Build and send a plain text email message."""
-    active_settings = settings or SmtpSettings.from_env()
-    send_email(
-        build_text_email(
-            from_email=active_settings.from_email,
-            to_email=to_email,
-            subject=subject,
-            body=body,
-        ),
-        settings=active_settings,
+    settings = settings or get_settings().smtp
+    mail = build_text_email(
+        from_email=settings.from_email,
+        to_email=to_email,
+        subject=subject,
+        body=body,
     )
+    send_email(mail, settings=settings)
 
 
 def send_email(
     message: EmailMessage,
     *,
-    settings: SmtpSettings | None = None,
+    settings: SmtpSettings,
     smtp_client_cls: Callable[..., Any] | None = None,
 ) -> None:
     """Send an email message through the configured SMTP server."""
-    active_settings = settings or SmtpSettings.from_env()
-    active_settings.validate()
-    client_cls = smtp_client_cls or (SMTP_SSL if active_settings.use_ssl else SMTP)
+    client_cls = smtp_client_cls or (SMTP_SSL if settings.USE_SSL else SMTP)
 
     try:
         with client_cls(
-            active_settings.host,
-            active_settings.port,
-            timeout=active_settings.timeout,
+            settings.HOST,
+            settings.PORT,
+            timeout=settings.TIMEOUT,
         ) as smtp:
-            if active_settings.use_tls:
+            if settings.USE_TLS:
                 smtp.starttls()
                 smtp.ehlo()
-            if active_settings.uses_authentication():
-                smtp.login(active_settings.username, active_settings.password)
+            if settings.USERNAME and settings.PASSWORD:
+                smtp.login(settings.USERNAME, settings.PASSWORD)
             smtp.send_message(message)
     except (OSError, SMTPException) as exc:
         raise EmailDeliveryError("Failed to send email via SMTP.") from exc

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -96,12 +96,26 @@ def register_success() -> rx.Component:
     """Render the successful registration message."""
     return rx.cond(
         MyRegisterState.success,
-        rx.callout(
-            LanguageState.successful_registration,
-            icon="check",
-            color_scheme="green",
-            role="alert",
-            width="100%",
+        rx.cond(
+            MyRegisterState.welcome_email_failed,
+            rx.callout(
+                LanguageState.successful_registration_email_failed,
+                icon="triangle_alert",
+                color_scheme="amber",
+                role="alert",
+                width="100%",
+            ),
+            rx.callout(
+                rx.cond(
+                    MyRegisterState.welcome_email_sent,
+                    LanguageState.successful_registration_with_email,
+                    LanguageState.successful_registration,
+                ),
+                icon="check",
+                color_scheme="green",
+                role="alert",
+                width="100%",
+            ),
         ),
     )
 
@@ -111,6 +125,11 @@ def register_form() -> rx.Component:
     privacy_notice = get_privacy_notice_short()
     return rx.form(
         rx.vstack(
+            rx.input(
+                type="hidden",
+                name="language",
+                value=LanguageState.language,
+            ),
             rx.heading(LanguageState.register_heading, size="7"),
             register_error(),
             register_success(),

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -141,6 +141,7 @@ def register_form() -> rx.Component:
                 custom_attrs={"auto_complete": "username"},
                 value=MyRegisterState.username,
                 on_change=MyRegisterState.set_username,
+                disabled=MyRegisterState.registration_in_progress,
             ),
             rx.text(LanguageState.email),
             input(
@@ -151,6 +152,7 @@ def register_form() -> rx.Component:
                 custom_attrs={"auto_complete": "email"},
                 value=MyRegisterState.email,
                 on_change=MyRegisterState.set_email,
+                disabled=MyRegisterState.registration_in_progress,
             ),
             rx.text(LanguageState.password),
             password_input(
@@ -160,6 +162,7 @@ def register_form() -> rx.Component:
                 custom_attrs={"auto_complete": "new-password"},
                 value=MyRegisterState.password,
                 on_change=MyRegisterState.set_password,
+                disabled=MyRegisterState.registration_in_progress,
             ),
             rx.text(LanguageState.confirm_password),
             password_input(
@@ -169,6 +172,7 @@ def register_form() -> rx.Component:
                 custom_attrs={"auto_complete": "new-password"},
                 value=MyRegisterState.confirm_password,
                 on_change=MyRegisterState.set_confirm_password,
+                disabled=MyRegisterState.registration_in_progress,
             ),
             rx.text(LanguageState.registration_code),
             input(
@@ -177,6 +181,7 @@ def register_form() -> rx.Component:
                 required=True,
                 value=MyRegisterState.registration_code,
                 on_change=MyRegisterState.set_registration_code,
+                disabled=MyRegisterState.registration_in_progress,
             ),
             rx.cond(
                 privacy_notice,

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -197,6 +197,8 @@ def register_form() -> rx.Component:
             ),
             rx.button(
                 LanguageState.register,
+                disabled=MyRegisterState.registration_in_progress,
+                loading=MyRegisterState.registration_in_progress,
                 width="100%",
                 _hover={"cursor": "pointer"},
             ),

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -1,16 +1,20 @@
 """State for the login and for the registration page."""
 
+import asyncio
+import logging
 import re
 
 import reflex as rx
 import reflex_local_auth
 from reflex_local_auth.user import LocalUser
 
-from aitutor.account_emails import send_signup_welcome
+from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
 from aitutor.language_state import language_from_value
 from aitutor.mail import EmailConfigurationError, EmailDeliveryError
 from aitutor.models import UserInfo, UserRole
+
+logger = logging.getLogger(__name__)
 
 
 class MyLoginState(reflex_local_auth.LoginState):
@@ -36,6 +40,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     registration_code: str = ""
     welcome_email_sent: bool = False
     welcome_email_failed: bool = False
+    registration_in_progress: bool = False
 
     @rx.event
     def set_username(self, value: str):
@@ -78,10 +83,11 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.registration_code = ""
         self.welcome_email_sent = False
         self.welcome_email_failed = False
+        self.registration_in_progress = False
 
     # This event handler must be named something besides `handle_registration`!!!
     @rx.event
-    def handle_custom_registration(self, form_data):
+    async def handle_custom_registration(self, form_data):
         """
         Handles the registration process for a user using their email.
 
@@ -91,24 +97,44 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         Returns:
             Any: The result of the registration process.
         """
-        language = language_from_value(form_data.get("language"))
-        # check for allowed user name
-        if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
-            self.error_message = (
-                "Username can only contain letters, numbers and '. _ -'"
+        self.registration_in_progress = True
+        self.success = False
+        self.welcome_email_sent = False
+        self.welcome_email_failed = False
+        self.error_message = ""
+        yield
+
+        try:
+            language = language_from_value(form_data.get("language"))
+            # check for allowed user name
+            if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
+                self.error_message = (
+                    "Username can only contain letters, numbers and '. _ -'"
+                )
+                self.username = ""
+                return
+
+            # check for the correct registration code
+            registration_code = get_config().registration_code
+            if form_data["registration_code"] != registration_code:
+                self.error_message = "The registration code is wrong."
+                self.registration_code = ""
+                return
+
+            validation_errors = self._validate_fields(
+                form_data["username"],
+                form_data["password"],
+                form_data["confirm_password"],
             )
-            self.username = ""
-            return
+            if validation_errors:
+                self.new_user_id = -1
+                yield validation_errors
+                return
 
-        # check for the correct registration code
-        registration_code = get_config().registration_code
-        if form_data["registration_code"] != registration_code:
-            self.error_message = "The registration code is wrong."
-            self.registration_code = ""
-            return
+            self._register_user(form_data["username"], form_data["password"])
+            if self.new_user_id < 0:
+                return
 
-        registration_result = self.handle_registration(form_data)
-        if self.new_user_id >= 0:
             welcome_email_sent = False
             welcome_email_failed = False
             with rx.session() as session:
@@ -123,16 +149,26 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 try:
                     local_user = session.get(LocalUser, self.new_user_id)
                     if local_user is not None:
-                        send_signup_welcome(
-                            local_user=local_user,
-                            user_info=user_info,
+                        await asyncio.to_thread(
+                            send_signup_welcome_email,
+                            to_email=user_info.email,
+                            username=local_user.username,
+                            language=user_info.language,
                         )
                         welcome_email_sent = True
                 except (EmailConfigurationError, EmailDeliveryError):
+                    logger.exception(
+                        "Failed to send signup welcome email for user_id=%s.",
+                        self.new_user_id,
+                    )
                     welcome_email_failed = True
+
             self.clear_state_vars()
             self.welcome_email_sent = welcome_email_sent
             self.welcome_email_failed = welcome_email_failed
             self.success = True
             self.error_message = ""
-        return registration_result
+            if not welcome_email_failed:
+                yield type(self).successful_registration
+        finally:
+            self.registration_in_progress = False

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -121,18 +121,9 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 self.registration_code = ""
                 return
 
-            validation_errors = self._validate_fields(
-                form_data["username"],
-                form_data["password"],
-                form_data["confirm_password"],
-            )
-            if validation_errors:
-                self.new_user_id = -1
-                yield validation_errors
-                return
-
-            self._register_user(form_data["username"], form_data["password"])
+            registration_result = self.handle_registration(form_data)
             if self.new_user_id < 0:
+                yield registration_result
                 return
 
             welcome_email_sent = False
@@ -169,6 +160,6 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
             self.success = True
             self.error_message = ""
             if not welcome_email_failed:
-                yield type(self).successful_registration
+                yield registration_result
         finally:
             self.registration_in_progress = False

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -112,7 +112,6 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
             welcome_email_sent = False
             welcome_email_failed = False
             with rx.session() as session:
-                local_user = session.get(LocalUser, self.new_user_id)
                 user_info = UserInfo(
                     email=form_data["email"],
                     role=UserRole.STUDENT,
@@ -122,6 +121,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 session.add(user_info)
                 session.commit()
                 try:
+                    local_user = session.get(LocalUser, self.new_user_id)
                     if local_user is not None:
                         send_signup_welcome(
                             local_user=local_user,

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -4,8 +4,12 @@ import re
 
 import reflex as rx
 import reflex_local_auth
+from reflex_local_auth.user import LocalUser
 
+from aitutor.account_emails import send_signup_welcome
 from aitutor.config import get_config
+from aitutor.language_state import language_from_value
+from aitutor.mail import EmailConfigurationError, EmailDeliveryError
 from aitutor.models import UserInfo, UserRole
 
 
@@ -30,6 +34,8 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     password: str = ""
     confirm_password: str = ""
     registration_code: str = ""
+    welcome_email_sent: bool = False
+    welcome_email_failed: bool = False
 
     @rx.event
     def set_username(self, value: str):
@@ -70,6 +76,8 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.password = ""
         self.confirm_password = ""
         self.registration_code = ""
+        self.welcome_email_sent = False
+        self.welcome_email_failed = False
 
     # This event handler must be named something besides `handle_registration`!!!
     @rx.event
@@ -83,6 +91,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         Returns:
             Any: The result of the registration process.
         """
+        language = language_from_value(form_data.get("language"))
         # check for allowed user name
         if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
             self.error_message = (
@@ -100,14 +109,30 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
 
         registration_result = self.handle_registration(form_data)
         if self.new_user_id >= 0:
-            self.clear_state_vars()
+            welcome_email_sent = False
+            welcome_email_failed = False
             with rx.session() as session:
-                session.add(
-                    UserInfo(
-                        email=form_data["email"],
-                        role=UserRole.STUDENT,
-                        user_id=self.new_user_id,
-                    )
+                local_user = session.get(LocalUser, self.new_user_id)
+                user_info = UserInfo(
+                    email=form_data["email"],
+                    role=UserRole.STUDENT,
+                    user_id=self.new_user_id,
+                    language=language,
                 )
+                session.add(user_info)
                 session.commit()
+                try:
+                    if local_user is not None:
+                        send_signup_welcome(
+                            local_user=local_user,
+                            user_info=user_info,
+                        )
+                        welcome_email_sent = True
+                except (EmailConfigurationError, EmailDeliveryError):
+                    welcome_email_failed = True
+            self.clear_state_vars()
+            self.welcome_email_sent = welcome_email_sent
+            self.welcome_email_failed = welcome_email_failed
+            self.success = True
+            self.error_message = ""
         return registration_result

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -137,22 +137,26 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 )
                 session.add(user_info)
                 session.commit()
-                try:
-                    local_user = session.get(LocalUser, self.new_user_id)
-                    if local_user is not None:
-                        await asyncio.to_thread(
-                            send_signup_welcome_email,
-                            to_email=user_info.email,
-                            username=local_user.username,
-                            language=user_info.language,
-                        )
-                        welcome_email_sent = True
-                except EmailDeliveryError:
-                    logger.exception(
-                        "Failed to send signup welcome email for user_id=%s.",
-                        self.new_user_id,
+                session.refresh(user_info)
+
+                local_user = session.get(LocalUser, self.new_user_id)
+                username = local_user.username if local_user else None
+
+            try:
+                if username:
+                    await asyncio.to_thread(
+                        send_signup_welcome_email,
+                        to_email=user_info.email,
+                        username=username,
+                        language=user_info.language,
                     )
-                    welcome_email_failed = True
+                    welcome_email_sent = True
+            except EmailDeliveryError:
+                logger.exception(
+                    "Failed to send signup welcome email for user_id=%s.",
+                    self.new_user_id,
+                )
+                welcome_email_failed = True
 
             self.clear_state_vars()
             self.welcome_email_sent = welcome_email_sent

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -11,7 +11,7 @@ from reflex_local_auth.user import LocalUser
 from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
 from aitutor.language_state import language_from_value
-from aitutor.mail import EmailConfigurationError, EmailDeliveryError
+from aitutor.mail import EmailDeliveryError
 from aitutor.models import UserInfo, UserRole
 
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                             language=user_info.language,
                         )
                         welcome_email_sent = True
-                except (EmailConfigurationError, EmailDeliveryError):
+                except EmailDeliveryError:
                     logger.exception(
                         "Failed to send signup welcome email for user_id=%s.",
                         self.new_user_id,

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -11,7 +11,6 @@ from reflex_local_auth.user import LocalUser
 from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
 from aitutor.language_state import language_from_value
-from aitutor.mail import EmailDeliveryError
 from aitutor.models import UserInfo, UserRole
 
 logger = logging.getLogger(__name__)
@@ -151,7 +150,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                         language=user_info.language,
                     )
                     welcome_email_sent = True
-            except EmailDeliveryError:
+            except Exception:
                 logger.exception(
                     "Failed to send signup welcome email for user_id=%s.",
                     self.new_user_id,

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -1,6 +1,7 @@
 """State for the login and for the registration page."""
 
 import asyncio
+import email.utils
 import logging
 import re
 
@@ -111,6 +112,17 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                     "Username can only contain letters, numbers and '. _ -'"
                 )
                 self.username = ""
+                return
+
+            # Very basic email syntax validation, mostly to catch erroneous user input.
+            # For a somewhat valid email address, parseaddr returns the address as
+            # second element of a tuple.  In addition, we check if there is at least an
+            # '@' in it.  For a syntactically invalid email address, parseaddr returns
+            # an empty string, thus always making the '@' in ...' check fail in this
+            # case.
+            if "@" not in email.utils.parseaddr(form_data["email"], strict=True)[1]:
+                self.error_message = "Email address is not valid."
+                self.email = ""
                 return
 
             # check for the correct registration code

--- a/aitutor/utilities/cprint.py
+++ b/aitutor/utilities/cprint.py
@@ -1,0 +1,89 @@
+"""Printing colored and styled text to the terminal using ANSI codes.
+
+The ``cprint`` function allows to easily print text with color and style (bold/faint).
+It is relatively basic but good enough for our purposes, so we don't need to add a
+third-party dependency for this.
+
+Example:
+```python
+cprint("Hello, World!", fg="green")
+cprint("Error!", fg="white", bg="red", style="bold")
+```
+"""
+
+from typing import Literal, cast
+
+color_codes_fg = {
+    "black": "30",
+    "red": "31",
+    "green": "32",
+    "yellow": "33",
+    "blue": "34",
+    "magenta": "35",
+    "cyan": "36",
+    "white": "37",
+}
+
+color_codes_bg = {
+    "black": "40",
+    "red": "41",
+    "green": "42",
+    "yellow": "43",
+    "blue": "44",
+    "magenta": "45",
+    "cyan": "46",
+    "white": "47",
+}
+
+style_codes = {
+    "bold": "1",
+    "faint": "2",
+}
+
+_color_t = Literal[
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"
+]
+_style_t = Literal["bold", "faint"]
+
+
+def cprint(
+    text: str,
+    *,
+    fg: _color_t | None = None,
+    bg: _color_t | None = None,
+    style: _style_t | None = None,
+) -> None:
+    """
+    Print styled/colored text to the terminal using ANSI codes.
+
+    Args:
+        text: The text to print.
+        fg: The foreground color. One of "black", "red", "green", "yellow", "blue",
+            "magenta", "cyan", or "white".
+        bg: The background color. One of "black", "red", "green", "yellow", "blue",
+            "magenta", "cyan", or "white".
+        style: The text style. One of "bold" or "faint".
+    """
+    codes = []
+    if fg is not None:
+        codes.append(color_codes_fg[fg])
+    if bg is not None:
+        codes.append(color_codes_bg[bg])
+    if style is not None:
+        codes.append(style_codes[style])
+    code_seq = ";".join(codes)
+
+    print(f"\x1b[{code_seq}m{text}\x1b[0m")
+
+
+def showcase() -> None:
+    """Showcase the available colors and styles."""
+    for style in [None, "bold", "faint"]:
+        for fg in color_codes_fg.keys():
+            for bg in color_codes_bg.keys():
+                cprint(
+                    f"fg={fg}, bg={bg}, style={style}",
+                    fg=cast(_color_t, fg),
+                    bg=cast(_color_t, bg),
+                    style=style,
+                )

--- a/compose.mailpit.yaml
+++ b/compose.mailpit.yaml
@@ -1,0 +1,12 @@
+# Use this override file to test SMTP delivery locally with Mailpit.
+#     docker compose -f compose.yaml -f compose.mailpit.yaml up
+services:
+  app:
+    depends_on:
+      - mailpit
+
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:1025:1025"

--- a/compose.mailpit.yaml
+++ b/compose.mailpit.yaml
@@ -1,10 +1,6 @@
 # Use this override file to test SMTP delivery locally with Mailpit.
 #     docker compose -f compose.yaml -f compose.mailpit.yaml up
 services:
-  app:
-    depends_on:
-      - mailpit
-
   mailpit:
     image: axllent/mailpit
     ports:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,26 +34,14 @@ SMTP_PASSWORD=your-smtp-password
 SMTP_USE_TLS=true
 SMTP_USE_SSL=false
 SMTP_TIMEOUT=10
-AITUTOR_PUBLIC_URL=https://your-ai-tutor.example
+DOMAIN=your-ai-tutor.example
 ```
 
 `SMTP_USERNAME` and `SMTP_PASSWORD` are optional only if the SMTP server allows
 unauthenticated sending.  If one is set, the other must be set as well.
 
-For University of Tuebingen SMTP, the documented server is typically:
-
-```
-SMTP_HOST=smtpserv.uni-tuebingen.de
-SMTP_PORT=587
-SMTP_USE_TLS=true
-```
-
-The SMTP username may be the ZDV-ID rather than the visible email address.  In
-that case, set `SMTP_USERNAME` to the ZDV-ID and set `SMTP_FROM_EMAIL` to the
-actual sender address that should appear on account emails.
-
-Signup welcome emails use `AITUTOR_PUBLIC_URL` to build login links.  Set it to
-the public URL users open in their browser.
+Signup welcome emails use `DOMAIN` to build HTTPS login links.  Set it to the
+public domain users open in their browser.
 
 Do not commit real SMTP credentials to the repository.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,6 +20,43 @@ Then open [https://localhost](https://localhost) in your browser to access the a
 
 The config files `config.toml` and `.env` are expected to be found in the projects root directory and are mounted into the container from the host system.  This means that the configuration can easily be changed without the need of rebuilding the images.
 
+## Email setup
+
+Signup welcome emails are sent through SMTP.  Configure the following values in
+`.env`:
+
+```
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_FROM_EMAIL="AI Tutor <noreply@example.com>"
+SMTP_USERNAME=your-smtp-user
+SMTP_PASSWORD=your-smtp-password
+SMTP_USE_TLS=true
+SMTP_USE_SSL=false
+SMTP_TIMEOUT=10
+AITUTOR_PUBLIC_URL=https://your-ai-tutor.example
+```
+
+`SMTP_USERNAME` and `SMTP_PASSWORD` are optional only if the SMTP server allows
+unauthenticated sending.  If one is set, the other must be set as well.
+
+For University of Tuebingen SMTP, the documented server is typically:
+
+```
+SMTP_HOST=smtpserv.uni-tuebingen.de
+SMTP_PORT=587
+SMTP_USE_TLS=true
+```
+
+The SMTP username may be the ZDV-ID rather than the visible email address.  In
+that case, set `SMTP_USERNAME` to the ZDV-ID and set `SMTP_FROM_EMAIL` to the
+actual sender address that should appear on account emails.
+
+Signup welcome emails use `AITUTOR_PUBLIC_URL` to build login links.  Set it to
+the public URL users open in their browser.
+
+Do not commit real SMTP credentials to the repository.
+
 
 ## Production environment with Postgresql
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -45,6 +45,29 @@ public domain users open in their browser.
 
 Do not commit real SMTP credentials to the repository.
 
+For local email testing without sending real mail, configure the app container
+to send signup emails to Mailpit:
+
+```
+SMTP_HOST=mailpit
+SMTP_PORT=1025
+SMTP_FROM_EMAIL="AI Tutor <noreply@example.test>"
+SMTP_USE_TLS=false
+SMTP_USE_SSL=false
+DOMAIN=localhost
+```
+
+Leave `SMTP_USERNAME` and `SMTP_PASSWORD` unset unless you configure Mailpit to
+require authentication.
+
+Then start the optional Mailpit compose override:
+
+```
+docker compose -f compose.yaml -f compose.mailpit.yaml up
+```
+
+Open [http://localhost:8025](http://localhost:8025) to inspect captured emails.
+
 
 ## Production environment with Postgresql
 

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -1,0 +1,100 @@
+from email.message import EmailMessage
+
+import pytest
+from reflex_local_auth.user import LocalUser
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from aitutor.account_emails import send_signup_welcome
+from aitutor.language_state import BackendTranslations as BT
+from aitutor.models import Language, UserInfo, UserRole
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def create_user(session: Session, *, language: Language = Language.EN) -> LocalUser:
+    user = LocalUser(
+        username="student",
+        password_hash=LocalUser.hash_password("old-password"),
+        enabled=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    assert user.id is not None
+    session.add(
+        UserInfo(
+            user_id=user.id,
+            email="student@example.com",
+            role=UserRole.STUDENT,
+            language=language,
+        )
+    )
+    session.commit()
+    return user
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_message"),
+    [
+        (Language.EN, "Welcome to AI Tutor"),
+        (Language.DE, "Willkommen bei AI Tutor"),
+    ],
+)
+def test_account_email_backend_translations(language, expected_message):
+    assert expected_message in BT.signup_welcome_subject(language)
+
+
+def test_send_signup_welcome_sends_email(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        user = create_user(session)
+        user_info = session.exec(select(UserInfo)).one()
+
+        send_signup_welcome(local_user=user, user_info=user_info)
+
+    assert len(sent_messages) == 1
+    assert sent_messages[0]["To"] == "student@example.com"
+    assert sent_messages[0]["Subject"] == "Welcome to AI Tutor"
+    assert "Username: student" in sent_messages[0].get_content()
+    assert "https://ai-tutor.example/login" in sent_messages[0].get_content()
+
+
+def test_send_signup_welcome_uses_user_language(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+
+    def fake_send_text_email(**kwargs):
+        message = EmailMessage()
+        message["To"] = kwargs["to_email"]
+        message["Subject"] = kwargs["subject"]
+        message.set_content(kwargs["body"])
+        sent_messages.append(message)
+
+    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
+
+    with make_session() as session:
+        user = create_user(session, language=Language.DE)
+        user_info = session.exec(select(UserInfo)).one()
+
+        send_signup_welcome(local_user=user, user_info=user_info)
+
+    assert sent_messages[0]["Subject"] == "Willkommen bei AI Tutor"
+    body = sent_messages[0].get_content()
+    assert "Hallo student" in body
+    assert "Benutzername: student" in body
+    assert "https://ai-tutor.example/login" in body

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -3,8 +3,16 @@ from email.message import EmailMessage
 import pytest
 
 from aitutor.account_emails import send_signup_welcome_email
+from aitutor.app_settings import get_settings
 from aitutor.language_state import BackendTranslations as BT
 from aitutor.models import Language
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -29,6 +37,7 @@ def test_send_signup_welcome_email_sends_email(monkeypatch):
         sent_messages.append(message)
 
     monkeypatch.setenv("DOMAIN", "ai-tutor.example")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
     send_signup_welcome_email(
@@ -55,6 +64,7 @@ def test_send_signup_welcome_email_uses_user_language(monkeypatch):
         sent_messages.append(message)
 
     monkeypatch.setenv("DOMAIN", "ai-tutor.example")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
     send_signup_welcome_email(

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -58,7 +58,7 @@ def test_send_signup_welcome_sends_email(monkeypatch):
         message.set_content(kwargs["body"])
         sent_messages.append(message)
 
-    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setenv("DOMAIN", "ai-tutor.example")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
     with make_session() as session:
@@ -84,7 +84,7 @@ def test_send_signup_welcome_uses_user_language(monkeypatch):
         message.set_content(kwargs["body"])
         sent_messages.append(message)
 
-    monkeypatch.setenv("AITUTOR_PUBLIC_URL", "https://ai-tutor.example")
+    monkeypatch.setenv("DOMAIN", "ai-tutor.example")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
     with make_session() as session:

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -1,40 +1,10 @@
 from email.message import EmailMessage
 
 import pytest
-from reflex_local_auth.user import LocalUser
-from sqlmodel import Session, SQLModel, create_engine, select
 
-from aitutor.account_emails import send_signup_welcome
+from aitutor.account_emails import send_signup_welcome_email
 from aitutor.language_state import BackendTranslations as BT
-from aitutor.models import Language, UserInfo, UserRole
-
-
-def make_session():
-    engine = create_engine("sqlite:///:memory:")
-    SQLModel.metadata.create_all(engine)
-    return Session(engine)
-
-
-def create_user(session: Session, *, language: Language = Language.EN) -> LocalUser:
-    user = LocalUser(
-        username="student",
-        password_hash=LocalUser.hash_password("old-password"),
-        enabled=True,
-    )
-    session.add(user)
-    session.commit()
-    session.refresh(user)
-    assert user.id is not None
-    session.add(
-        UserInfo(
-            user_id=user.id,
-            email="student@example.com",
-            role=UserRole.STUDENT,
-            language=language,
-        )
-    )
-    session.commit()
-    return user
+from aitutor.models import Language
 
 
 @pytest.mark.parametrize(
@@ -48,7 +18,7 @@ def test_account_email_backend_translations(language, expected_message):
     assert expected_message in BT.signup_welcome_subject(language)
 
 
-def test_send_signup_welcome_sends_email(monkeypatch):
+def test_send_signup_welcome_email_sends_email(monkeypatch):
     sent_messages: list[EmailMessage] = []
 
     def fake_send_text_email(**kwargs):
@@ -61,11 +31,11 @@ def test_send_signup_welcome_sends_email(monkeypatch):
     monkeypatch.setenv("DOMAIN", "ai-tutor.example")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
-    with make_session() as session:
-        user = create_user(session)
-        user_info = session.exec(select(UserInfo)).one()
-
-        send_signup_welcome(local_user=user, user_info=user_info)
+    send_signup_welcome_email(
+        to_email="student@example.com",
+        username="student",
+        language=Language.EN,
+    )
 
     assert len(sent_messages) == 1
     assert sent_messages[0]["To"] == "student@example.com"
@@ -74,7 +44,7 @@ def test_send_signup_welcome_sends_email(monkeypatch):
     assert "https://ai-tutor.example/login" in sent_messages[0].get_content()
 
 
-def test_send_signup_welcome_uses_user_language(monkeypatch):
+def test_send_signup_welcome_email_uses_user_language(monkeypatch):
     sent_messages: list[EmailMessage] = []
 
     def fake_send_text_email(**kwargs):
@@ -87,11 +57,11 @@ def test_send_signup_welcome_uses_user_language(monkeypatch):
     monkeypatch.setenv("DOMAIN", "ai-tutor.example")
     monkeypatch.setattr("aitutor.account_emails.send_text_email", fake_send_text_email)
 
-    with make_session() as session:
-        user = create_user(session, language=Language.DE)
-        user_info = session.exec(select(UserInfo)).one()
-
-        send_signup_welcome(local_user=user, user_info=user_info)
+    send_signup_welcome_email(
+        to_email="student@example.com",
+        username="student",
+        language=Language.DE,
+    )
 
     assert sent_messages[0]["Subject"] == "Willkommen bei AI Tutor"
     body = sent_messages[0].get_content()

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -76,3 +76,22 @@ def test_app_settings_treats_empty_openai_base_url_as_none(monkeypatch):
     monkeypatch.setenv("OPENAI_BASE_URL", " ")
 
     assert make_settings(env_file=None).openai_base_url is None
+
+
+def test_app_settings_defaults_optional_smtp_fields_to_none(monkeypatch):
+    """Unset optional SMTP strings remain distinguishable from configured values."""
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    for env_var in (
+        "SMTP_HOST",
+        "SMTP_FROM_EMAIL",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    settings = make_settings(env_file=None)
+
+    assert settings.smtp_host is None
+    assert settings.smtp_from_email is None
+    assert settings.smtp_username is None
+    assert settings.smtp_password is None

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -78,20 +78,94 @@ def test_app_settings_treats_empty_openai_base_url_as_none(monkeypatch):
     assert make_settings(env_file=None).openai_base_url is None
 
 
-def test_app_settings_defaults_optional_smtp_fields_to_none(monkeypatch):
-    """Unset optional SMTP strings remain distinguishable from configured values."""
+def test_app_settings_smtp_optional(monkeypatch):
+    """If no SMTP values are set, the settings object will be None."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     for env_var in (
         "SMTP_HOST",
         "SMTP_FROM_EMAIL",
         "SMTP_USERNAME",
         "SMTP_PASSWORD",
+        "SMTP_USE_TLS",
+        "SMTP_USE_SSL",
     ):
         monkeypatch.delenv(env_var, raising=False)
 
     settings = make_settings(env_file=None)
 
-    assert settings.smtp_host is None
-    assert settings.smtp_from_email is None
-    assert settings.smtp_username is None
-    assert settings.smtp_password is None
+    assert settings.SMTP is None
+
+
+def test_smtp_settings_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SMTP_HOST", "smtpserv.uni-tuebingen.de")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "AI Tutor <noreply@example.com>")
+    monkeypatch.setenv("SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("SMTP_PASSWORD", "smtp-password")
+    monkeypatch.setenv("SMTP_USE_TLS", "true")
+    monkeypatch.setenv("SMTP_USE_SSL", "false")
+
+    settings = make_settings(env_file=None)
+
+    assert settings.SMTP is not None
+    assert settings.SMTP.HOST == "smtpserv.uni-tuebingen.de"
+    assert settings.SMTP.PORT == 587
+    assert settings.SMTP.FROM_EMAIL == "AI Tutor <noreply@example.com>"
+    assert settings.SMTP.USERNAME == "smtp-user"
+    assert settings.SMTP.PASSWORD == "smtp-password"
+    assert settings.SMTP.USE_TLS is True
+    assert settings.SMTP.USE_SSL is False
+
+
+def test_smtp_settings_default_to_no_tls(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.delenv("SMTP_USE_TLS", raising=False)
+    monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+
+    settings = make_settings(env_file=None)
+
+    assert settings.SMTP is not None
+    assert settings.SMTP.USE_TLS is False
+    assert settings.SMTP.USE_SSL is False
+
+
+def test_smtp_settings_require_host(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+
+    with pytest.raises(ValidationError, match="HOST"):
+        make_settings(env_file=None)
+
+
+def test_smtp_settings_require_port(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("SMTP_PORT", raising=False)
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+
+    with pytest.raises(ValidationError, match="PORT"):
+        make_settings(env_file=None)
+
+
+def test_smtp_settings_require_from_email(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("SMTP_FROM_EMAIL", raising=False)
+    monkeypatch.setenv("SMTP_HOST", "smtp@example.com")
+
+    with pytest.raises(ValidationError, match="FROM_EMAIL"):
+        make_settings(env_file=None)
+
+
+def test_smtp_settings_reject_partial_credentials(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "123")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.setenv("SMTP_USERNAME", "foobar")
+
+    with pytest.raises(ValidationError, match="SMTP_PASSWORD"):
+        make_settings(env_file=None)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -22,6 +22,7 @@ class FakeSmtpClient:
         self.started_tls = False
         self.login_args = None
         self.sent_messages = []
+        self.calls = []
         FakeSmtpClient.instances.append(self)
 
     def __enter__(self):
@@ -31,12 +32,18 @@ class FakeSmtpClient:
         return None
 
     def starttls(self):
+        self.calls.append("starttls")
         self.started_tls = True
 
+    def ehlo(self):
+        self.calls.append("ehlo")
+
     def login(self, username, password):
+        self.calls.append("login")
         self.login_args = (username, password)
 
     def send_message(self, message):
+        self.calls.append("send_message")
         self.sent_messages.append(message)
 
 
@@ -124,5 +131,6 @@ def test_send_email_uses_starttls_and_authentication():
     assert client.port == 587
     assert client.timeout == 10
     assert client.started_tls is True
+    assert client.calls == ["starttls", "ehlo", "login", "send_message"]
     assert client.login_args == ("smtp-user", "smtp-password")
     assert client.sent_messages == [message]

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,0 +1,128 @@
+from email.message import EmailMessage
+
+import pytest
+
+from aitutor.mail import (
+    EmailConfigurationError,
+    SmtpSettings,
+    build_text_email,
+    send_email,
+)
+
+
+class FakeSmtpClient:
+    """SMTP client test double that records calls without sending email."""
+
+    instances = []
+
+    def __init__(self, host, port, timeout):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.started_tls = False
+        self.login_args = None
+        self.sent_messages = []
+        FakeSmtpClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def starttls(self):
+        self.started_tls = True
+
+    def login(self, username, password):
+        self.login_args = (username, password)
+
+    def send_message(self, message):
+        self.sent_messages.append(message)
+
+
+def test_smtp_settings_from_env(monkeypatch):
+    monkeypatch.setenv("SMTP_HOST", "smtpserv.uni-tuebingen.de")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "AI Tutor <noreply@example.com>")
+    monkeypatch.setenv("SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("SMTP_PASSWORD", "smtp-password")
+    monkeypatch.setenv("SMTP_USE_TLS", "true")
+    monkeypatch.setenv("SMTP_USE_SSL", "false")
+
+    settings = SmtpSettings.from_env()
+
+    assert settings.host == "smtpserv.uni-tuebingen.de"
+    assert settings.port == 587
+    assert settings.from_email == "AI Tutor <noreply@example.com>"
+    assert settings.username == "smtp-user"
+    assert settings.password == "smtp-password"
+    assert settings.use_tls is True
+    assert settings.use_ssl is False
+    assert settings.uses_authentication is True
+
+
+def test_smtp_settings_require_host(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+
+    with pytest.raises(EmailConfigurationError, match="SMTP_HOST"):
+        SmtpSettings.from_env()
+
+
+def test_smtp_settings_reject_partial_credentials():
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="noreply@example.com",
+        username="smtp-user",
+    )
+
+    with pytest.raises(EmailConfigurationError, match="SMTP_USERNAME"):
+        settings.validate()
+
+
+def test_build_text_email_uses_configured_sender():
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="AI Tutor <noreply@example.com>",
+    )
+
+    message = build_text_email(
+        to_email="student@example.com",
+        subject="Confirm your AI Tutor account",
+        body="Welcome to AI Tutor.",
+        settings=settings,
+    )
+
+    assert message["From"] == "AI Tutor <noreply@example.com>"
+    assert message["To"] == "student@example.com"
+    assert message["Subject"] == "Confirm your AI Tutor account"
+    assert message.get_content() == "Welcome to AI Tutor.\n"
+
+
+def test_send_email_uses_starttls_and_authentication():
+    FakeSmtpClient.instances.clear()
+    settings = SmtpSettings(
+        host="smtp.example.com",
+        port=587,
+        from_email="noreply@example.com",
+        username="smtp-user",
+        password="smtp-password",
+        use_tls=True,
+    )
+    message = EmailMessage()
+    message["From"] = settings.from_email
+    message["To"] = "student@example.com"
+    message["Subject"] = "Test"
+    message.set_content("Body")
+
+    send_email(message, settings=settings, smtp_client_cls=FakeSmtpClient)
+
+    client = FakeSmtpClient.instances[0]
+    assert client.host == "smtp.example.com"
+    assert client.port == 587
+    assert client.timeout == 10
+    assert client.started_tls is True
+    assert client.login_args == ("smtp-user", "smtp-password")
+    assert client.sent_messages == [message]

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -77,6 +77,19 @@ def test_smtp_settings_from_env(monkeypatch):
     assert settings.uses_authentication is True
 
 
+def test_smtp_settings_default_to_no_tls(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.delenv("SMTP_USE_TLS", raising=False)
+    monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+
+    settings = SmtpSettings.from_env()
+
+    assert settings.use_tls is False
+    assert settings.use_ssl is False
+
+
 def test_smtp_settings_require_host(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.delenv("SMTP_HOST", raising=False)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -99,16 +99,6 @@ def test_smtp_settings_require_host(monkeypatch):
         SmtpSettings.from_env()
 
 
-def test_smtp_settings_reject_invalid_port(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
-    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
-    monkeypatch.setenv("SMTP_PORT", "0")
-
-    with pytest.raises(EmailConfigurationError, match="SMTP_PORT"):
-        SmtpSettings.from_env()
-
-
 def test_smtp_settings_reject_partial_credentials():
     settings = SmtpSettings(
         host="smtp.example.com",

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -2,12 +2,20 @@ from email.message import EmailMessage
 
 import pytest
 
+from aitutor.app_settings import get_settings
 from aitutor.mail import (
     EmailConfigurationError,
     SmtpSettings,
     build_text_email,
     send_email,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 class FakeSmtpClient:
@@ -48,6 +56,7 @@ class FakeSmtpClient:
 
 
 def test_smtp_settings_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("SMTP_HOST", "smtpserv.uni-tuebingen.de")
     monkeypatch.setenv("SMTP_PORT", "587")
     monkeypatch.setenv("SMTP_FROM_EMAIL", "AI Tutor <noreply@example.com>")
@@ -69,6 +78,7 @@ def test_smtp_settings_from_env(monkeypatch):
 
 
 def test_smtp_settings_require_host(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.delenv("SMTP_HOST", raising=False)
     monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -86,6 +86,16 @@ def test_smtp_settings_require_host(monkeypatch):
         SmtpSettings.from_env()
 
 
+def test_smtp_settings_reject_invalid_port(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+    monkeypatch.setenv("SMTP_PORT", "0")
+
+    with pytest.raises(EmailConfigurationError, match="SMTP_PORT"):
+        SmtpSettings.from_env()
+
+
 def test_smtp_settings_reject_partial_credentials():
     settings = SmtpSettings(
         host="smtp.example.com",

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -2,10 +2,8 @@ from email.message import EmailMessage
 
 import pytest
 
-from aitutor.app_settings import get_settings
+from aitutor.app_settings import SmtpSettings, get_settings
 from aitutor.mail import (
-    EmailConfigurationError,
-    SmtpSettings,
     build_text_email,
     send_email,
 )
@@ -55,62 +53,6 @@ class FakeSmtpClient:
         self.sent_messages.append(message)
 
 
-def test_smtp_settings_from_env(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("SMTP_HOST", "smtpserv.uni-tuebingen.de")
-    monkeypatch.setenv("SMTP_PORT", "587")
-    monkeypatch.setenv("SMTP_FROM_EMAIL", "AI Tutor <noreply@example.com>")
-    monkeypatch.setenv("SMTP_USERNAME", "smtp-user")
-    monkeypatch.setenv("SMTP_PASSWORD", "smtp-password")
-    monkeypatch.setenv("SMTP_USE_TLS", "true")
-    monkeypatch.setenv("SMTP_USE_SSL", "false")
-
-    settings = SmtpSettings.from_env()
-
-    assert settings.host == "smtpserv.uni-tuebingen.de"
-    assert settings.port == 587
-    assert settings.from_email == "AI Tutor <noreply@example.com>"
-    assert settings.username == "smtp-user"
-    assert settings.password == "smtp-password"
-    assert settings.use_tls is True
-    assert settings.use_ssl is False
-    assert settings.uses_authentication() is True
-
-
-def test_smtp_settings_default_to_no_tls(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
-    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
-    monkeypatch.delenv("SMTP_USE_TLS", raising=False)
-    monkeypatch.delenv("SMTP_USE_SSL", raising=False)
-
-    settings = SmtpSettings.from_env()
-
-    assert settings.use_tls is False
-    assert settings.use_ssl is False
-
-
-def test_smtp_settings_require_host(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.delenv("SMTP_HOST", raising=False)
-    monkeypatch.setenv("SMTP_FROM_EMAIL", "noreply@example.com")
-
-    with pytest.raises(EmailConfigurationError, match="SMTP_HOST"):
-        SmtpSettings.from_env()
-
-
-def test_smtp_settings_reject_partial_credentials():
-    settings = SmtpSettings(
-        host="smtp.example.com",
-        port=587,
-        from_email="noreply@example.com",
-        username="smtp-user",
-    )
-
-    with pytest.raises(EmailConfigurationError, match="SMTP_USERNAME"):
-        settings.validate()
-
-
 def test_build_text_email_uses_configured_sender():
     message = build_text_email(
         from_email="AI Tutor <noreply@example.com>",
@@ -128,15 +70,15 @@ def test_build_text_email_uses_configured_sender():
 def test_send_email_uses_starttls_and_authentication():
     FakeSmtpClient.instances.clear()
     settings = SmtpSettings(
-        host="smtp.example.com",
-        port=587,
-        from_email="noreply@example.com",
-        username="smtp-user",
-        password="smtp-password",
-        use_tls=True,
+        HOST="smtp.example.com",
+        PORT=587,
+        FROM_EMAIL="noreply@example.com",
+        USERNAME="smtp-user",
+        PASSWORD="smtp-password",
+        USE_TLS=True,
     )
     message = EmailMessage()
-    message["From"] = settings.from_email
+    message["From"] = settings.FROM_EMAIL
     message["To"] = "student@example.com"
     message["Subject"] = "Test"
     message.set_content("Body")

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -74,7 +74,7 @@ def test_smtp_settings_from_env(monkeypatch):
     assert settings.password == "smtp-password"
     assert settings.use_tls is True
     assert settings.use_ssl is False
-    assert settings.uses_authentication is True
+    assert settings.uses_authentication() is True
 
 
 def test_smtp_settings_default_to_no_tls(monkeypatch):

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -112,17 +112,11 @@ def test_smtp_settings_reject_partial_credentials():
 
 
 def test_build_text_email_uses_configured_sender():
-    settings = SmtpSettings(
-        host="smtp.example.com",
-        port=587,
-        from_email="AI Tutor <noreply@example.com>",
-    )
-
     message = build_text_email(
+        from_email="AI Tutor <noreply@example.com>",
         to_email="student@example.com",
         subject="Confirm your AI Tutor account",
         body="Welcome to AI Tutor.",
-        settings=settings,
     )
 
     assert message["From"] == "AI Tutor <noreply@example.com>"


### PR DESCRIPTION
I picked up #351 so we can eventually merge it (most of the functionality was already done there).

Changes I made on top of #351 are:
- Refactoring to simplify the configuration of SMTP settings.
- Making SMTP settings optional.  If not set, the email text will be printed to terminal.  This is mostly to not disrupt current development.  The better approach is to run mailpit (see `compose.mailpit.yaml`) to verify emails are properly sent.
- Added basic email validation during the registration
- A few minor changes