### PR TITLE
Rename AppSettings to EnvSettings

### DIFF
--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -1,13 +1,13 @@
 """Account welcome email helpers."""
 
-from aitutor.app_settings import get_settings
+from aitutor.env_settings import get_env_settings
 from aitutor.mail import send_text_email
 from aitutor.models import Language
 
 
 def public_base_url() -> str:
     """Public base URL used for links in account emails."""
-    return f"https://{get_settings().domain}".rstrip("/")
+    return f"https://{get_env_settings().domain}".rstrip("/")
 
 
 def send_signup_welcome_email(

--- a/aitutor/account_emails.py
+++ b/aitutor/account_emails.py
@@ -7,7 +7,7 @@ from aitutor.models import Language
 
 def public_base_url() -> str:
     """Public base URL used for links in account emails."""
-    return f"https://{get_env_settings().domain}".rstrip("/")
+    return f"https://{get_env_settings().DOMAIN}".rstrip("/")
 
 
 def send_signup_welcome_email(

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -196,8 +196,8 @@ def initialize():
         cprint(f"Error loading settings: {e}", fg="white", bg="red")
         sys.exit(1)
 
-    if settings.openai_base_url:
-        print(f"Using OPENAI_BASE_URL={settings.openai_base_url}")
+    if settings.OPENAI_BASE_URL:
+        print(f"Using OPENAI_BASE_URL={settings.OPENAI_BASE_URL}")
 
     if not settings.SMTP:
         cprint(

--- a/aitutor/aitutor.py
+++ b/aitutor/aitutor.py
@@ -10,8 +10,8 @@ from sqlmodel import select
 
 import aitutor.routes as routes
 from aitutor import pages
-from aitutor.app_settings import get_settings
 from aitutor.config import add_configprompts_to_db, get_config, initialize_config_db
+from aitutor.env_settings import get_env_settings
 from aitutor.models import Prompt
 from aitutor.utilities.cprint import cprint
 from aitutor.utilities.create_default_users import create_default_users
@@ -191,7 +191,7 @@ def initialize():
         sys.exit(1)
 
     try:
-        settings = get_settings()
+        settings = get_env_settings()
     except ValueError as e:
         cprint(f"Error loading settings: {e}", fg="white", bg="red")
         sys.exit(1)

--- a/aitutor/env_settings.py
+++ b/aitutor/env_settings.py
@@ -66,19 +66,19 @@ class EnvSettings(BaseSettings):
         extra="ignore",
     )
 
-    openai_api_key: Annotated[
+    OPENAI_API_KEY: Annotated[
         str, StringConstraints(strip_whitespace=True, min_length=1)
     ] = Field(validation_alias="OPENAI_API_KEY")
-    openai_base_url: str | None = Field(
+    OPENAI_BASE_URL: str | None = Field(
         default=None, validation_alias="OPENAI_BASE_URL"
     )
-    domain: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+    DOMAIN: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
         default="localhost", validation_alias="DOMAIN"
     )
 
     SMTP: SmtpSettings | None = None
 
-    @field_validator("openai_base_url", mode="before")
+    @field_validator("OPENAI_BASE_URL", mode="before")
     @classmethod
     def _empty_openai_base_url_as_none(cls, value: object) -> object:
         """Treat an empty optional base URL as unset."""

--- a/aitutor/env_settings.py
+++ b/aitutor/env_settings.py
@@ -55,7 +55,7 @@ class SmtpSettings(BaseModel):
         return self
 
 
-class AppSettings(BaseSettings):
+class EnvSettings(BaseSettings):
     """Settings loaded from environment variables and the project `.env` file."""
 
     model_config = SettingsConfigDict(
@@ -88,6 +88,6 @@ class AppSettings(BaseSettings):
 
 
 @lru_cache
-def get_settings() -> AppSettings:
+def get_env_settings() -> EnvSettings:
     """Return cached app settings."""
-    return AppSettings()  # pyright: ignore[reportCallIssue]
+    return EnvSettings()  # pyright: ignore[reportCallIssue]

--- a/aitutor/env_settings.py
+++ b/aitutor/env_settings.py
@@ -18,17 +18,17 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class SmtpSettings(BaseModel):
     """Settings for SMTP email sending."""
 
-    HOST: str = Field(validation_alias="HOST")
-    PORT: int = Field(validation_alias="PORT")
-    FROM_EMAIL: str = Field(validation_alias="FROM_EMAIL")
+    HOST: str
+    PORT: int
+    FROM_EMAIL: str
 
-    USERNAME: str | None = Field(default=None, validation_alias="USERNAME")
-    PASSWORD: str | None = Field(default=None, validation_alias="PASSWORD")
+    USERNAME: str | None = Field(default=None)
+    PASSWORD: str | None = Field(default=None)
 
-    USE_TLS: bool = Field(default=False, validation_alias="USE_TLS")
-    USE_SSL: bool = Field(default=False, validation_alias="USE_SSL")
+    USE_TLS: bool = Field(default=False)
+    USE_SSL: bool = Field(default=False)
 
-    TIMEOUT: int = Field(default=10, validation_alias="TIMEOUT")
+    TIMEOUT: int = Field(default=10)
 
     @field_validator("PORT", "TIMEOUT", mode="after")
     @classmethod
@@ -68,13 +68,9 @@ class EnvSettings(BaseSettings):
 
     OPENAI_API_KEY: Annotated[
         str, StringConstraints(strip_whitespace=True, min_length=1)
-    ] = Field(validation_alias="OPENAI_API_KEY")
-    OPENAI_BASE_URL: str | None = Field(
-        default=None, validation_alias="OPENAI_BASE_URL"
-    )
-    DOMAIN: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
-        default="localhost", validation_alias="DOMAIN"
-    )
+    ]
+    OPENAI_BASE_URL: str | None = Field(default=None)
+    DOMAIN: str = Field(default="localhost")
 
     SMTP: SmtpSettings | None = None
 

--- a/aitutor/mail.py
+++ b/aitutor/mail.py
@@ -4,7 +4,7 @@ from email.message import EmailMessage
 from smtplib import SMTP, SMTP_SSL, SMTPException
 from typing import Any, Callable
 
-from aitutor.app_settings import SmtpSettings, get_settings
+from aitutor.env_settings import SmtpSettings, get_env_settings
 
 
 class EmailDeliveryError(RuntimeError):
@@ -35,7 +35,7 @@ def send_text_email(
     settings: SmtpSettings | None = None,
 ) -> None:
     """Build and send a plain text email message."""
-    settings = settings or get_settings().SMTP
+    settings = settings or get_env_settings().SMTP
 
     # settings may be None, which means no SMTP is configured.  In this case, simply
     # print the email to stdout for debugging.

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -70,8 +70,8 @@ def init_async_openai_client() -> AsyncOpenAI:
     """
     settings = get_env_settings()
     return AsyncOpenAI(
-        api_key=settings.openai_api_key,
-        base_url=settings.openai_base_url,
+        api_key=settings.OPENAI_API_KEY,
+        base_url=settings.OPENAI_BASE_URL,
     )
 
 

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -11,10 +11,10 @@ from pydantic import BaseModel
 from sqlmodel import select
 
 import aitutor.routes as routes
-from aitutor.app_settings import get_settings
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.config import get_config
+from aitutor.env_settings import get_env_settings
 from aitutor.global_vars import (
     CHAT_MESSAGE_CHAR_LIMIT,
     CHAT_TOKEN_WARNING_THRESHOLD,
@@ -68,7 +68,7 @@ def init_async_openai_client() -> AsyncOpenAI:
     Uses settings so the API key and optional base URL can be set either as environment
     variables or in a .env file.
     """
-    settings = get_settings()
+    settings = get_env_settings()
     return AsyncOpenAI(
         api_key=settings.openai_api_key,
         base_url=settings.openai_base_url,

--- a/tests/test_account_emails.py
+++ b/tests/test_account_emails.py
@@ -3,16 +3,16 @@ from email.message import EmailMessage
 import pytest
 
 from aitutor.account_emails import send_signup_welcome_email
-from aitutor.app_settings import get_settings
+from aitutor.env_settings import get_env_settings
 from aitutor.language_state import BackendTranslations as BT
 from aitutor.models import Language
 
 
 @pytest.fixture(autouse=True)
 def clear_settings_cache():
-    get_settings.cache_clear()
+    get_env_settings.cache_clear()
     yield
-    get_settings.cache_clear()
+    get_env_settings.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_env_settings.py
+++ b/tests/test_env_settings.py
@@ -24,7 +24,7 @@ def test_env_settings_reads_openai_api_key_from_env(monkeypatch):
     """OPENAI_API_KEY can come from the real process environment."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
 
-    assert make_settings(env_file=None).openai_api_key == "env-key"
+    assert make_settings(env_file=None).OPENAI_API_KEY == "env-key"
 
 
 def test_env_settings_reads_openai_api_key_from_cwd_dotenv(tmp_path, monkeypatch):
@@ -33,7 +33,7 @@ def test_env_settings_reads_openai_api_key_from_cwd_dotenv(tmp_path, monkeypatch
     monkeypatch.chdir(tmp_path)
     Path(".env").write_text("OPENAI_API_KEY=dotenv-key\nOTHER_VALUE=ignored\n")
 
-    assert make_settings(env_file=".env").openai_api_key == "dotenv-key"
+    assert make_settings(env_file=".env").OPENAI_API_KEY == "dotenv-key"
 
 
 def test_env_settings_requires_openai_api_key(monkeypatch):
@@ -59,7 +59,7 @@ def test_env_settings_reads_optional_openai_base_url(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text("OPENAI_BASE_URL=https://example.test/v1\n")
 
-    assert make_settings(env_file=env_file).openai_base_url == "https://example.test/v1"
+    assert make_settings(env_file=env_file).OPENAI_BASE_URL == "https://example.test/v1"
 
 
 def test_env_settings_defaults_openai_base_url_to_none(monkeypatch):
@@ -67,7 +67,7 @@ def test_env_settings_defaults_openai_base_url_to_none(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-    assert make_settings(env_file=None).openai_base_url is None
+    assert make_settings(env_file=None).OPENAI_BASE_URL is None
 
 
 def test_env_settings_treats_empty_openai_base_url_as_none(monkeypatch):
@@ -75,7 +75,7 @@ def test_env_settings_treats_empty_openai_base_url_as_none(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     monkeypatch.setenv("OPENAI_BASE_URL", " ")
 
-    assert make_settings(env_file=None).openai_base_url is None
+    assert make_settings(env_file=None).OPENAI_BASE_URL is None
 
 
 def test_env_settings_smtp_optional(monkeypatch):

--- a/tests/test_env_settings.py
+++ b/tests/test_env_settings.py
@@ -4,13 +4,13 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
-from aitutor.app_settings import AppSettings
+from aitutor.env_settings import EnvSettings
 
 
-def make_settings(env_file: str | Path | None) -> AppSettings:
+def make_settings(env_file: str | Path | None) -> EnvSettings:
     """Create settings with a test-controlled dotenv source."""
 
-    class TestSettings(AppSettings):
+    class TestSettings(EnvSettings):
         model_config = SettingsConfigDict(
             env_file=env_file,
             env_file_encoding="utf-8",
@@ -20,14 +20,14 @@ def make_settings(env_file: str | Path | None) -> AppSettings:
     return TestSettings()  # pyright: ignore[reportCallIssue]
 
 
-def test_app_settings_reads_openai_api_key_from_env(monkeypatch):
+def test_env_settings_reads_openai_api_key_from_env(monkeypatch):
     """OPENAI_API_KEY can come from the real process environment."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
 
     assert make_settings(env_file=None).openai_api_key == "env-key"
 
 
-def test_app_settings_reads_openai_api_key_from_cwd_dotenv(tmp_path, monkeypatch):
+def test_env_settings_reads_openai_api_key_from_cwd_dotenv(tmp_path, monkeypatch):
     """OPENAI_API_KEY can come from the current working directory dotenv file."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.chdir(tmp_path)
@@ -36,7 +36,7 @@ def test_app_settings_reads_openai_api_key_from_cwd_dotenv(tmp_path, monkeypatch
     assert make_settings(env_file=".env").openai_api_key == "dotenv-key"
 
 
-def test_app_settings_requires_openai_api_key(monkeypatch):
+def test_env_settings_requires_openai_api_key(monkeypatch):
     """Missing OPENAI_API_KEY raises a clear configuration error."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -44,7 +44,7 @@ def test_app_settings_requires_openai_api_key(monkeypatch):
         make_settings(env_file=None)
 
 
-def test_app_settings_rejects_empty_openai_api_key(monkeypatch):
+def test_env_settings_rejects_empty_openai_api_key(monkeypatch):
     """OPENAI_API_KEY cannot be empty."""
     monkeypatch.setenv("OPENAI_API_KEY", " ")
 
@@ -52,7 +52,7 @@ def test_app_settings_rejects_empty_openai_api_key(monkeypatch):
         make_settings(env_file=None)
 
 
-def test_app_settings_reads_optional_openai_base_url(tmp_path, monkeypatch):
+def test_env_settings_reads_optional_openai_base_url(tmp_path, monkeypatch):
     """OPENAI_BASE_URL can come from a dotenv file when configured."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -62,7 +62,7 @@ def test_app_settings_reads_optional_openai_base_url(tmp_path, monkeypatch):
     assert make_settings(env_file=env_file).openai_base_url == "https://example.test/v1"
 
 
-def test_app_settings_defaults_openai_base_url_to_none(monkeypatch):
+def test_env_settings_defaults_openai_base_url_to_none(monkeypatch):
     """OPENAI_BASE_URL is optional."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -70,7 +70,7 @@ def test_app_settings_defaults_openai_base_url_to_none(monkeypatch):
     assert make_settings(env_file=None).openai_base_url is None
 
 
-def test_app_settings_treats_empty_openai_base_url_as_none(monkeypatch):
+def test_env_settings_treats_empty_openai_base_url_as_none(monkeypatch):
     """Empty OPENAI_BASE_URL is equivalent to leaving it unset."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     monkeypatch.setenv("OPENAI_BASE_URL", " ")
@@ -78,7 +78,7 @@ def test_app_settings_treats_empty_openai_base_url_as_none(monkeypatch):
     assert make_settings(env_file=None).openai_base_url is None
 
 
-def test_app_settings_smtp_optional(monkeypatch):
+def test_env_settings_smtp_optional(monkeypatch):
     """If no SMTP values are set, the settings object will be None."""
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     for env_var in (

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -2,7 +2,7 @@ from email.message import EmailMessage
 
 import pytest
 
-from aitutor.app_settings import SmtpSettings, get_settings
+from aitutor.env_settings import SmtpSettings, get_env_settings
 from aitutor.mail import (
     build_text_email,
     send_email,
@@ -11,9 +11,9 @@ from aitutor.mail import (
 
 @pytest.fixture(autouse=True)
 def clear_settings_cache():
-    get_settings.cache_clear()
+    get_env_settings.cache_clear()
     yield
-    get_settings.cache_clear()
+    get_env_settings.cache_clear()
 
 
 class FakeSmtpClient:


### PR DESCRIPTION
This is an attempt to reduce the confusion between "config" and "app settings".  The app settings are those values that are read from the environment (either env variables or .env file), so renaming it to "env settings" hopefully makes it clearer.

Further changes:
- Changed all fields to upper case to be consistent with `SmtpSettings`.
- Removed the validation_aliases, which exactly matched the field names and were thus not needed.

**Do not merge before**
- #394 