### PR TITLE
Use state.reset() to clear all data on logout

### DIFF
--- a/aitutor/auth/state.py
+++ b/aitutor/auth/state.py
@@ -74,45 +74,15 @@ class SessionState(reflex_local_auth.LocalAuthState):
         """
         Handles the logout process for the authenticated user.
         """
-        from aitutor import pages
-
-        states = [
-            pages.AllLecturesState,
-            pages.ChatState,
-            pages.EditLectureState,
-            pages.HomeState,
-            pages.ExercisesState,
-            pages.FinishedViewState,
-            pages.FinishedViewTutorState,
-            pages.LectureExercisesState,
-            pages.LectureManageExercisesState,
-            pages.LectureManagePromptsState,
-            pages.LectureManageTagsState,
-            pages.LectureMembersState,
-            pages.LectureOverviewState,
-            pages.LectureReportsState,
-            pages.LectureReportViewState,
-            pages.LectureSubmissionsState,
-            pages.LectureTokenAnalyzerState,
-            pages.ManageConfigState,
-            pages.ManageExercisesState,
-            pages.ManageTagsState,
-            pages.ManagePromptsState,
-            pages.ManageUsersState,
-            pages.MyLecturesState,
-            pages.ReportsState,
-            pages.ReportViewState,
-            pages.SubmissionsState,
-            pages.TokenAnalyzerState,
-        ]
-        for state in states:
-            # get the state
-            state_instance = await self.get_state(state)
-            # clear the state
-            state_instance.on_logout()
-
-        # logout
         self.do_logout()
+
+        # Reset all base vars to their default (this also covers substates).
+        # We want to keep the language setting after logout, so restore that after
+        # resetting.
+        language = self.language
+        self.reset()
+        self.language = language
+
         return rx.redirect(routes.HOME, replace=True)
 
     @rx.var(cache=True, initial_value=None)

--- a/aitutor/pages/all_lectures/state.py
+++ b/aitutor/pages/all_lectures/state.py
@@ -170,11 +170,6 @@ class AllLecturesState(SessionState):
             return rx.redirect(routes.NOT_FOUND)
         return self.open_join_dialog(lecture_id)
 
-    def on_logout(self):
-        """Clear page-specific state on logout."""
-        self.lectures = []
-        self._reset_page_state()
-
     @rx.var(initial_value=[])
     def filtered_lectures(self) -> list[LectureWithRole]:
         """Return loaded lectures filtered locally by the search text."""

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -312,23 +312,6 @@ class ChatState(SessionState):
         else:
             yield
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self._exercise_id = -1
-        self.messages = []
-        self.current_exercise = None
-        self.exercise_title = "No Exercise Selected"
-        self.system_message_gpt = ""
-        self.waiting_for_response = False
-        self.check_passed = False
-        self.conversation_is_submitted = False
-        self.submit_time_stamp = ""
-        self.user_input = ""
-        self.last_user_message_index = -1
-        self.is_overdue = False
-        self._userinfo_id = -1
-        self.current_lecture_id = None
-
     @rx.var
     def report_char_count(self) -> int:
         """Get the current character count of the report text."""

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -65,11 +65,6 @@ class ManageConfigState(SessionState):
         self.global_load()
         self.unsaved_changes = False
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.unsaved_changes = False
-        self.current_config = empty_config
-
     @rx.event
     def save_config_to_db(self):
         """Saves the current configuration to the database."""

--- a/aitutor/pages/edit_lecture/state.py
+++ b/aitutor/pages/edit_lecture/state.py
@@ -83,12 +83,6 @@ class EditLectureState(SessionState):
                 return rx.redirect(routes.NOT_FOUND)
             self._apply_lecture_to_state(lecture)
 
-    def on_logout(self):
-        """Clear lecture-specific state on logout."""
-        self._reset_form()
-        self.lecture_id_param = MAGIC_ID_NEW
-        self.delete_confirmation_password = ""
-
     @rx.event
     @state_require_role_or_permission(required_role=UserRole.STUDENT)
     def save_lecture(self):

--- a/aitutor/pages/exercises/state.py
+++ b/aitutor/pages/exercises/state.py
@@ -59,14 +59,6 @@ class ExercisesState(FilterMixin, SessionState):
         assert self.authenticated_user_info is not None
         self.load_exercises()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.exercises_with_result = []
-        self.open_deadline_exercises = []
-        self.no_deadline_exercises = []
-        self.closed_deadline_exercises = []
-        self.time_left_strings = {}
-
     @rx.var
     def submit_time_stamps(self) -> dict[int, str]:
         """

--- a/aitutor/pages/finished_view/state.py
+++ b/aitutor/pages/finished_view/state.py
@@ -79,14 +79,6 @@ class FinishedViewState(SessionState):
                 self.messages = []
                 self.set_messages_from_conversation(finished_conversation)
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self._exercise_id = -1
-        self.messages = []
-        self.current_exercise = None
-        self.exercise_title = "No Exercise Selected"
-        self.current_lecture_id = None
-
     @rx.var
     def chat_url(self) -> str:
         """Returns the URL for the chat page."""

--- a/aitutor/pages/finished_view_tutor/state.py
+++ b/aitutor/pages/finished_view_tutor/state.py
@@ -64,14 +64,6 @@ class FinishedViewTutorState(SessionState):
             self.messages = []
             self.set_messages_from_conversation(finished_conversation)
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.messages = []
-        self.current_exercise = None
-        self.username = ""
-        self.exercise_title = "No Exercise Selected"
-        self.current_lecture_id = None
-
     @rx.var
     def submissions_url(self) -> str:
         """Return to the matching global or lecture-specific submissions page."""

--- a/aitutor/pages/home/state.py
+++ b/aitutor/pages/home/state.py
@@ -56,10 +56,6 @@ class HomeState(SessionState):
                 if not exercise.is_hidden and exercise.is_started
             ]
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.exercises_with_result = []
-
     @rx.var
     def completed_exercises_num(self) -> int:
         """Number of completed exercises."""

--- a/aitutor/pages/lecture_exercises/state.py
+++ b/aitutor/pages/lecture_exercises/state.py
@@ -75,10 +75,6 @@ class LectureExercisesState(FilterMixin, SessionState):
 
         self.load_exercises()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self._clear_exercises()
-
     @rx.var
     def route_lecture_id(self) -> str:
         """Return the lecture id route parameter for lecture-specific navigation."""

--- a/aitutor/pages/lecture_manage_exercises/state.py
+++ b/aitutor/pages/lecture_manage_exercises/state.py
@@ -192,29 +192,6 @@ class LectureManageExercisesState(FilterMixin, SessionState):
                 lecture_id=lecture_id,
             )
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.exercises = []
-        self.current_lecture_id = None
-        self.current_default_prompt_id = None
-        self.tag_list = []
-        self.tag_names = []
-        self.search_values = []  # from FilterMixin
-        self.current_exercise = Exercise()
-        self.selected_tags = []
-        self.lesson_context = ""
-        self.lesson_file_name = ""
-        self.current_prompt_id = ""
-        self.prompts = []
-        self.extracting_lesson_material = False
-        self.current_hidden_state = False
-        self.current_deadline = ""
-        self.current_days_to_complete = ""
-        self.use_deadline = True
-        self.editing_periods = {}
-        self.exercise_is_started = {}
-        self.exercise_is_selected = {}
-
     @rx.var
     def selectable_tags(self) -> list[str]:
         """Return the list of tags that can be selected (not already selected)."""
@@ -924,12 +901,6 @@ class LectureManageTagsState(LectureManageExercisesState):
     def set_new_renamed_tag_name(self, tag_name: str):
         """Set the renamed tag name."""
         self.new_renamed_tag_name = tag_name
-
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.new_tag_name = ""
-        self.new_renamed_tag_name = ""
-        self.editing_tag_id = None
 
     @rx.var(initial_value={})
     def exercises_per_tag(self) -> dict[int, int]:

--- a/aitutor/pages/lecture_members/state.py
+++ b/aitutor/pages/lecture_members/state.py
@@ -95,10 +95,6 @@ class LectureMembersState(SessionState):
         self.load_members()
         self.load_available_users()
 
-    def on_logout(self):
-        """Clear page-specific state on logout."""
-        self._reset_page_state()
-
     @rx.var(initial_value=False)
     def is_owner(self) -> bool:
         """Whether the current user is an owner of this lecture."""

--- a/aitutor/pages/lecture_overview/state.py
+++ b/aitutor/pages/lecture_overview/state.py
@@ -48,10 +48,6 @@ class LectureOverviewState(SessionState):
         assert self.authenticated_user_info is not None
         self._load_lecture_exercises()
 
-    def on_logout(self):
-        """Clear lecture-specific state when the user logs out."""
-        self._reset_lecture_state()
-
     def _reset_lecture_state(self) -> None:
         """Reset all page-local state values."""
         self.current_lecture_id = None

--- a/aitutor/pages/lecture_prompts/state.py
+++ b/aitutor/pages/lecture_prompts/state.py
@@ -102,18 +102,6 @@ class LectureManagePromptsState(SessionState):
         self.current_lecture_id = lecture_id
         self.load_prompts_from_db()
 
-    def on_logout(self):
-        """Clear state when the user logs out."""
-        self.current_lecture_id = None
-        self.current_default_prompt_id = None
-        self.unsaved_changes = False
-        self.prompts = {}
-        self.replacement_prompt_id = ""
-        self.prompt_to_delete_id = None
-        self.new_prompt_name = ""
-        self.new_prompt_template = ""
-        self.add_prompt_dialog_open = False
-
     def _user_may_manage_lecture(self, lecture_id: int) -> bool:
         """Return whether the current user may manage prompts in this lecture."""
         if self.authenticated_user is None or self.authenticated_user.id is None:

--- a/aitutor/pages/lecture_report_view/state.py
+++ b/aitutor/pages/lecture_report_view/state.py
@@ -53,13 +53,6 @@ class LectureReportViewState(SessionState):
         self.reports_route = f"{routes.LECTURE_REPORTS}/{lecture_id}"
         self.load_report()
 
-    def on_logout(self):
-        """Clear state when user logs out."""
-        self._report_id = -1
-        self.current_lecture_id = None
-        self.reports_route = routes.MY_LECTURES
-        self._clear_report_data()
-
     @rx.event
     def load_report(self):
         """Load lecture-specific report and associated conversation from database."""

--- a/aitutor/pages/lecture_reports/state.py
+++ b/aitutor/pages/lecture_reports/state.py
@@ -73,12 +73,6 @@ class LectureReportsState(FilterMixin, SessionState):
         self.current_lecture_id = lecture_id
         self.load_reports()
 
-    def on_logout(self):
-        """Clear state when user logs out."""
-        self.current_lecture_id = None
-        self.table_rows = []
-        self.search_values = []
-
     @override
     @rx.event
     def load_filtered_data(self):

--- a/aitutor/pages/lecture_submissions/state.py
+++ b/aitutor/pages/lecture_submissions/state.py
@@ -88,12 +88,6 @@ class LectureSubmissionsState(FilterMixin, SessionState):
                 lecture_id=lecture_id,
             )
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.current_lecture_id = None
-        self.table_rows = []
-        self.search_values = []  # from FilterMixin
-
     @override
     @rx.event
     def load_filtered_data(self):

--- a/aitutor/pages/lecture_token_analyzer/state.py
+++ b/aitutor/pages/lecture_token_analyzer/state.py
@@ -135,11 +135,6 @@ class LectureTokenAnalyzerState(SessionState):
         self.load_user_token_rows()
         self.load_exercise_token_rows()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.current_lecture_id = None
-        self._clear_token_analyzer_state()
-
     def _clear_token_analyzer_state(self):
         """Clear loaded token analyzer state."""
         self.user_table_rows = []

--- a/aitutor/pages/manage_exercises/state.py
+++ b/aitutor/pages/manage_exercises/state.py
@@ -147,28 +147,6 @@ class ManageExercisesState(FilterMixin, SessionState):
         self.load_exercises()
         self.extracting_lesson_material = False
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.exercises = []
-        self.tag_list = []
-        self.tag_names = []
-        self.search_values = []  # from FilterMixin
-        self.current_exercise = Exercise()
-        self.selected_tags = []
-        self.lesson_context = ""
-        self.lesson_file_name = ""
-        self.current_prompt_name = ""
-        self.prompts = []
-        self.prompt_names = []
-        self.extracting_lesson_material = False
-        self.current_hidden_state = False
-        self.current_deadline = ""
-        self.current_days_to_complete = ""
-        self.use_deadline = True
-        self.editing_periods = {}
-        self.exercise_is_started = {}
-        self.exercise_is_selected = {}
-
     @rx.var
     def selectable_tags(self) -> list[str]:
         """Return the list of tags that can be selected (not already selected)."""
@@ -840,12 +818,6 @@ class ManageTagsState(ManageExercisesState):
     def set_new_renamed_tag_name(self, tag_name: str):
         """Set the renamed tag name."""
         self.new_renamed_tag_name = tag_name
-
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.new_tag_name = ""
-        self.new_renamed_tag_name = ""
-        self.editing_tag_id = None
 
     @rx.var(initial_value={})
     def exercises_per_tag(self) -> dict[int, int]:

--- a/aitutor/pages/manage_users/state.py
+++ b/aitutor/pages/manage_users/state.py
@@ -36,13 +36,6 @@ class ManageUsersState(SessionState):
         self.global_load()
         self.load_users()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.users = []
-        self.edited_user = None
-        self.edited_user_permissions = []
-        self.edit_dialog_is_open = False
-
     def load_users(self):
         """Load the users from the database."""
         # Define role order for sorting (based on definition order in the database enum,

--- a/aitutor/pages/my_lectures/state.py
+++ b/aitutor/pages/my_lectures/state.py
@@ -100,10 +100,6 @@ class MyLecturesState(SessionState):
         self._reset_filters()
         self.load_joined_lectures()
 
-    def on_logout(self):
-        """Clear page-specific state on logout."""
-        self._reset_filters()
-
     @rx.var(initial_value=[])
     def filtered_lectures(self) -> list[LectureWithRole]:
         """Return lectures filtered by search text and role."""

--- a/aitutor/pages/prompts/state.py
+++ b/aitutor/pages/prompts/state.py
@@ -84,16 +84,6 @@ class ManagePromptsState(SessionState):
         self.global_load()
         self.load_prompts_from_db()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.unsaved_changes = False
-        self.prompts = {}
-        self.replacement_prompt_name = ""
-        self.prompt_to_delete = ""
-        self.new_prompt_name = ""
-        self.new_prompt_template = ""
-        self.add_prompt_dialog_open = False
-
     @rx.var
     def remaining_prompt_names(self) -> list[str]:
         """Returns the names of the prompts excluding the one to delete."""

--- a/aitutor/pages/report_view/state.py
+++ b/aitutor/pages/report_view/state.py
@@ -29,15 +29,6 @@ class ReportViewState(SessionState):
         self._report_id = self.get_route_param_or_error("report_id", dtype=int)
         self.load_report()
 
-    def on_logout(self):
-        """Clear state when user logs out."""
-        self._report_id = -1
-        self.report_text = ""
-        self.looked_at = False
-        self.exercise_title = ""
-        self.username = ""
-        self.messages = []
-
     @rx.event
     def load_report(self):
         """Load report and associated conversation from database."""

--- a/aitutor/pages/reports/state.py
+++ b/aitutor/pages/reports/state.py
@@ -52,11 +52,6 @@ class ReportsState(FilterMixin, SessionState):
         self.global_load()
         self.load_reports()
 
-    def on_logout(self):
-        """Clear state when user logs out."""
-        self.table_rows = []
-        self.search_values = []
-
     @override
     @rx.event
     def load_filtered_data(self):

--- a/aitutor/pages/submissions/state.py
+++ b/aitutor/pages/submissions/state.py
@@ -49,11 +49,6 @@ class SubmissionsState(FilterMixin, SessionState):
         self.global_load()
         self.load_submissions()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.table_rows = []
-        self.search_values = []  # from FilterMixin
-
     @override
     @rx.event
     def load_filtered_data(self):

--- a/aitutor/pages/token_analyzer/state.py
+++ b/aitutor/pages/token_analyzer/state.py
@@ -109,24 +109,6 @@ class TokenAnalyzerState(SessionState):
         self.load_user_token_rows()
         self.load_exercise_token_rows()
 
-    def on_logout(self):
-        """Clears the state when the user logs out."""
-        self.user_table_rows = []
-        self.user_chart_data = []
-        self.user_chart_ticks = []
-        self.active_analysis_view = USER_ANALYSIS_VIEW
-        self.exercise_options = []
-        self.selected_exercise_name = ALL_EXERCISES_OPTION
-        self.exercise_filter_query = ""
-        self.exercise_table_rows = []
-        self.exercise_chart_data = []
-        self.exercise_chart_ticks = []
-        self.exercise_bar_size = 3
-        self.user_options = []
-        self.selected_user_name = ALL_USERS_OPTION
-        self.user_filter_query = ""
-        self.user_bar_size = 3
-
     @rx.var(initial_value="All")
     def all_option_label(self) -> str:
         """Localized label for the 'all' select option."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,17 +25,19 @@ State files contain the functions that are used to process data and handle user 
 
 A state usually always has these two functions:
 - an `on_load()` function that is called when the page is loaded and therefore can be used to initialize variables. This function needs to be protected with the `@state_require_role_at_least(userrole)` decorator so that no data is loaded for unauthorized users.
-- an `on_logout()` function to ensure that all user-specific data is cleared when the user logs out.
 
 To keep the state classes readable for everyone, we always order its content in the following order:
 - state variables
 - setters for state variables
 - on_load function
-- on_logout function
 - @rx.var functions
 - regular functions
 
 Information that is needed globally (e.g. the user language) is stored in the SessionState that is located in `aitutor/auth/state.py`. This state also handles the logout process. It has a function `global_load()` that should be called in every pages `on_load()` function to ensure that global data is consistent.
+
+All substates that are derived from `SessionState` are automatically reset upon logout.
+State information that should be preserved when the user logs out, needs to be saved in
+a State class that does not inherit (directly or indirectly) from `SessionState`.
 
 ## Languages
 


### PR DESCRIPTION
Picking up #364.

Instead of manually listing all substates to call their `on_logout`
function, simply call `reset()` on the `SessionState`.  This resets all
base variables to their default, including all substates.

This means that all states that inherit from `SessionState` will be
complete reset upon logout without having to take care of it explicitly.

This means the `on_logout` methods are now obsolete and are removed.

There is currently one value, which we want to preserve upon logout: the
language setting.  Since it's just one flag, I manually restore it after
the reset().  A more proper solution (if we get more such fields in the
future) would be to move them to some separate state class that does not
inherit from `SessionState` (and thus doesn't get reset on logout).

An alternative approach would have been to dynamically get the list of
substates using `self.substates.values()` (see the implementation of the
`reset()` method) and call their `on_logout()` method.  This would allow
for more flexibility (e.g. for cases like language), but still bears the
risk of forgetting to add fields in the `on_logout()` method.  Hence I
decided to go for the fully-automatic `reset()`.


Closes #363 
Closes #362