### PR TITLE
fix: use proper var operation in lecture cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ tmp/
 *.swp
 
 .claude/settings.local.json
+.agents/

--- a/aitutor/pages/my_lectures/components.py
+++ b/aitutor/pages/my_lectures/components.py
@@ -204,7 +204,7 @@ def lecture_action_buttons(
     return rx.hstack(
         enter_lecture_button(lecture, width=button_width),
         rx.cond(
-            role is not None,
+            role != None,
             leave_lecture_button(lecture, width=button_width),
         ),
         spacing="2",


### PR DESCRIPTION
## Problem
When checking the nullability of objects using `is`, it is gonna compile down to `True` always

## Solution
Use the right operation from the official doc https://reflex.dev/docs/vars/var-operations/#comparisons-and-mathematical-operators

## Changes
<img width="1147" height="401" alt="image" src="https://github.com/user-attachments/assets/a9e23341-d91f-4c2f-bd0f-536dba93a6cb" />

## Test
1. log in
2. go to lectures page
3. u should see the `leave lecture` buttons only next to joined lectures 

## Fixes
https://github.com/martius-lab/ai-tutor/issues/388