### PR TITLE
Add GitHub workflow to check `reflex db makemigrations`

### DIFF
--- a/.github/workflows/reflex_db.yml
+++ b/.github/workflows/reflex_db.yml
@@ -1,6 +1,5 @@
 name: "reflex db"
 
-# Run on pull requests and when merging to main branch
 on:
   pull_request:
 
@@ -8,7 +7,7 @@ permissions:
   contents: read
 
 jobs:
-  migrate:
+  migrate_and_makemigrations:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -21,3 +20,9 @@ jobs:
 
       - name: Run reflex db migrate
         run: uv run reflex db migrate
+
+      - name: Run reflex db makemigrations
+        run: |
+          out=$(uv run reflex db makemigrations 2>&1)
+          echo $out
+          test -z "$out"

--- a/.github/workflows/reflex_db.yml
+++ b/.github/workflows/reflex_db.yml
@@ -1,17 +1,14 @@
-name: Tests
+name: "reflex db"
 
 # Run on pull requests and when merging to main branch
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  pytest:
+  migrate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -22,5 +19,5 @@ jobs:
       - name: Install the project
         run: uv sync
 
-      - name: Run tests
-        run: uv run pytest tests/
+      - name: Run reflex db migrate
+        run: uv run reflex db migrate


### PR DESCRIPTION
- Move the reflex database checks into a separate file
- Add a check verifying that `reflex db makemigrations` has no output.

This is to avoid that some change on the models is merged without the corresponding migration script.