### PR TITLE
Grant 'lecturer' permission to accounts created via magic link

### DIFF
--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -1294,10 +1294,24 @@ Please test the chat for functionality after changing the model.
         )
 
     @rx.var
+    def registration_with_lecturer_token_info(self) -> str:
+        return self.translate(
+            de="Registrierung als Dozent/-in",
+            en="Registration as lecturer",
+        )
+
+    @rx.var
     def lecturer_registration_token_dialog_title(self) -> str:
         return self.translate(
             de="Neues Registrierungstoken für Dozenten erstellen",
             en="Create new registration token for lecturers",
+        )
+
+    @rx.var
+    def lecturer_registration_token_invalid(self) -> str:
+        return self.translate(
+            de="Ungültiges oder abgelaufenes Registrierungstoken für Dozenten",
+            en="Invalid or expired lecturer registration token.",
         )
 
     # Report Strings -------------------------------------------------------------------

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -120,19 +120,44 @@ def register_success() -> rx.Component:
     )
 
 
+def lecturer_token_info() -> rx.Component:
+    """Show a note if a 'lecturer registration token' is used."""
+    return rx.cond(
+        MyRegisterState.lecturer_registration_token != "",
+        rx.callout(
+            LanguageState.registration_with_lecturer_token_info,
+            icon="info",
+            color_scheme="blue",
+            role="alert",
+            width="100%",
+        ),
+    )
+
+
 def register_form() -> rx.Component:
     """Render the registration form."""
     privacy_notice = get_privacy_notice_short()
     return rx.form(
         rx.vstack(
+            rx.heading(LanguageState.register_heading, size="7"),
+            lecturer_token_info(),
+            register_error(),
+            register_success(),
             rx.input(
                 type="hidden",
                 name="language",
                 value=LanguageState.language,
+                style={"display": "none"},
             ),
-            rx.heading(LanguageState.register_heading, size="7"),
-            register_error(),
-            register_success(),
+            rx.cond(
+                MyRegisterState.lecturer_registration_token != "",
+                rx.input(
+                    type="hidden",
+                    name="lecturer_registration_token",
+                    value=MyRegisterState.lecturer_registration_token,
+                    style={"display": "none"},
+                ),
+            ),
             rx.text(LanguageState.username),
             input(
                 "username",
@@ -219,4 +244,29 @@ def register_form() -> rx.Component:
             min_width=MIN_WIDTH,
         ),
         on_submit=MyRegisterState.handle_custom_registration,
+    )
+
+
+def invalid_registration_token_error() -> rx.Component:
+    """Error message for invalid/expired lecturer registration tokens."""
+    return rx.vstack(
+        rx.heading(LanguageState.register_heading, size="7"),
+        rx.callout(
+            LanguageState.lecturer_registration_token_invalid,
+            icon="triangle_alert",
+            color_scheme="red",
+            role="alert",
+            width="100%",
+        ),
+        min_width=MIN_WIDTH,
+        spacing="4",
+    )
+
+
+def register_form_wrapper() -> rx.Component:
+    """Wrap the register form with a check for invalid registration tokens."""
+    return rx.cond(
+        MyRegisterState.has_invalid_registration_token,
+        invalid_registration_token_error(),
+        register_form(),
     )

--- a/aitutor/pages/login_and_registration/page.py
+++ b/aitutor/pages/login_and_registration/page.py
@@ -6,7 +6,7 @@ from reflex_local_auth.pages.registration import RegistrationState
 
 from aitutor.pages.login_and_registration.components import (
     login_form,
-    register_form,
+    register_form_wrapper,
 )
 from aitutor.pages.navbar import with_navbar
 
@@ -36,7 +36,7 @@ def custom_register_page() -> rx.Component:
     return rx.center(
         rx.cond(
             RegistrationState.is_hydrated,
-            rx.card(register_form()),
+            rx.card(register_form_wrapper()),
         ),
         margin_top="2em",
         margin_bottom="2em",

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -4,15 +4,25 @@ import asyncio
 import email.utils
 import logging
 import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import reflex as rx
 import reflex_local_auth
 from reflex_local_auth.user import LocalUser
+from sqlmodel import func, select
 
 from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
+from aitutor.global_vars import TIME_ZONE
 from aitutor.language_state import language_from_value
-from aitutor.models import UserInfo, UserRole
+from aitutor.models import (
+    GlobalPermission,
+    LecturerRegistrationToken,
+    Permission,
+    UserInfo,
+    UserRole,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +54,9 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
 
     #: Whether a registration code is required for registration.
     needs_registration_code: bool = False
+
+    lecturer_registration_token: str = ""
+    has_invalid_registration_token: bool = False
 
     @rx.event
     def set_username(self, value: str):
@@ -77,6 +90,18 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.error_message = ""
         self.success = False
         self.needs_registration_code = bool(get_config().registration_code)
+
+        # Important: Clear the token to prevent a previous value from being used even if
+        # the current URL does not contain a token.
+        self.lecturer_registration_token = ""
+        self.has_invalid_registration_token = False
+
+        lecturer_registration_token = self.router.url.query_parameters.get("lrt", "")
+        if lecturer_registration_token:
+            if self._validate_lecturer_registration_token(lecturer_registration_token):
+                self.lecturer_registration_token = lecturer_registration_token
+            else:
+                self.has_invalid_registration_token = True
 
     def clear_state_vars(self):
         """Clear the state variables."""
@@ -145,8 +170,6 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 yield registration_result
                 return
 
-            welcome_email_sent = False
-            welcome_email_failed = False
             with rx.session() as session:
                 user_info = UserInfo(
                     email=form_data["email"],
@@ -155,12 +178,39 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                     language=language,
                 )
                 session.add(user_info)
+
+                # if valid 'lecturer registration token' is provided, assign the
+                # 'lecturer' permission
+                lecturer_registration_token = form_data.get(
+                    "lecturer_registration_token"
+                )
+                if (
+                    lecturer_registration_token
+                    and self._validate_lecturer_registration_token(
+                        lecturer_registration_token
+                    )
+                ):
+                    session.add(
+                        Permission(
+                            user_id=self.new_user_id,
+                            permission=GlobalPermission.LECTURER,
+                        )
+                    )
+                    # log the usage of the lecturer registration token (makes it easier
+                    # to analyse potential abuse)
+                    print(
+                        f"User {form_data['username']} ({self.new_user_id}) registered"
+                        f" as lecturer using token {lecturer_registration_token}."
+                    )
+
                 session.commit()
                 session.refresh(user_info)
 
                 local_user = session.get(LocalUser, self.new_user_id)
                 username = local_user.username if local_user else None
 
+            welcome_email_sent = False
+            welcome_email_failed = False
             try:
                 if username:
                     await asyncio.to_thread(
@@ -186,3 +236,22 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
                 yield registration_result
         finally:
             self.registration_in_progress = False
+
+    def _validate_lecturer_registration_token(self, token: str) -> bool:
+        """
+        Check whether the given lecturer registration token exists and hasn't expired.
+
+        Args:
+            token: The lecturer registration token to validate.
+
+        Returns:
+            bool: True if the token is valid, False otherwise.
+        """
+        now = datetime.now(ZoneInfo(TIME_ZONE))
+        with rx.session() as session:
+            stmt = select(func.count()).where(
+                LecturerRegistrationToken.token == token,
+                LecturerRegistrationToken.expires_at > now,
+            )
+            result = session.exec(stmt).one()
+            return result == 1


### PR DESCRIPTION
When a valid lecturer registration token is passed to the 'register' page as `?lrt=...` parameter, the new account will automatically be granted the 'lecturer' permission.