### PR TITLE
Make registration code optional

### DIFF
--- a/aitutor/language_state.py
+++ b/aitutor/language_state.py
@@ -882,8 +882,8 @@ class LanguageState(SessionState):
     def registration_code_placeholder(self) -> str:
         """Registration code placeholder string"""
         return self.translate(
-            de="Sie bekommen diesen Code von Ihrem Lehrer",
-            en="You get this code from your teacher",
+            de="Sie bekommen diesen Code von Ihrer Dozentin/Ihrem Dozenten",
+            en="You get this code from your lecturer",
         )
 
     # Manage Users Page Strings --------------------------------------------------------
@@ -994,9 +994,14 @@ class LanguageState(SessionState):
     @rx.var
     def registration_code_info(self) -> str:
         return self.translate(
-            de="Der Registrierungscode, den Studenten bei der Registrierung "
-            "eingeben müssen.",
-            en="The registration code that students have to enter during registration.",
+            de=(
+                "Code der für die Registrierung eines Kontos erforderlich ist."
+                "  Leer lassen, um die Registrierung ohne Code zu ermöglichen."
+            ),
+            en=(
+                "Code that is required to register an account.  Leave empty to allow"
+                " registration without a code."
+            ),
         )
 
     @rx.var

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -174,14 +174,19 @@ def register_form() -> rx.Component:
                 on_change=MyRegisterState.set_confirm_password,
                 disabled=MyRegisterState.registration_in_progress,
             ),
-            rx.text(LanguageState.registration_code),
-            input(
-                "registration_code",
-                placeholder=LanguageState.registration_code_placeholder,
-                required=True,
-                value=MyRegisterState.registration_code,
-                on_change=MyRegisterState.set_registration_code,
-                disabled=MyRegisterState.registration_in_progress,
+            rx.cond(
+                MyRegisterState.needs_registration_code,
+                rx.fragment(
+                    rx.text(LanguageState.registration_code),
+                    input(
+                        "registration_code",
+                        placeholder=LanguageState.registration_code_placeholder,
+                        required=True,
+                        value=MyRegisterState.registration_code,
+                        on_change=MyRegisterState.set_registration_code,
+                        disabled=MyRegisterState.registration_in_progress,
+                    ),
+                ),
             ),
             rx.cond(
                 privacy_notice,

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -42,6 +42,9 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     welcome_email_failed: bool = False
     registration_in_progress: bool = False
 
+    #: Whether a registration code is required for registration.
+    needs_registration_code: bool = False
+
     @rx.event
     def set_username(self, value: str):
         """Set the username."""
@@ -73,6 +76,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.clear_state_vars()
         self.error_message = ""
         self.success = False
+        self.needs_registration_code = bool(get_config().registration_code)
 
     def clear_state_vars(self):
         """Clear the state variables."""
@@ -84,6 +88,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         self.welcome_email_sent = False
         self.welcome_email_failed = False
         self.registration_in_progress = False
+        self.needs_registration_code = False
 
     # This event handler must be named something besides `handle_registration`!!!
     @rx.event
@@ -127,7 +132,10 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
 
             # check for the correct registration code
             registration_code = get_config().registration_code
-            if form_data["registration_code"] != registration_code:
+            if (
+                registration_code
+                and form_data["registration_code"] != registration_code
+            ):
                 self.error_message = "The registration code is wrong."
                 self.registration_code = ""
                 return


### PR DESCRIPTION
We likely don't want to guard the general account registration with a code anymore but it might still be nice to have to option to turn it back on (e.g. to restrict registration on test instances).

To achieve both, keep the general logic but only ask for the code during registration if the configured code is non-empty.  So to disable the registration code, one can simply set it to an empty string in the settings.