### PR TITLE
Upgrade to PostgreSQL 18

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,12 +2,12 @@
 #     docker compose -f compose.yaml -f compose.prod.yaml up -d
 services:
   db:
-    image: postgres@sha256:073e7c8b84e2197f94c8083634640ab37105effe1bc853ca4d5fbece3219b0e8
+    image: postgres:18
     restart: always
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
 
   redis:
     image: redis


### PR DESCRIPTION
Since the mount of the data changed, **this will break existing setups!** Make sure to backup the database first, if it contains any valuable data.

In development environments where the database can simply be discarded, you can simply delete the old 'postgres-data' volume first, e.g. with
```
docker volume rm ai-tutor_posrgres-data
```
The prefix of the volume name may differ in your environment, use `docker volume list` to check.