### PR TITLE
feat: limit the text input from users in exercise management page

### DIFF
--- a/aitutor/pages/lecture_manage_exercises/components.py
+++ b/aitutor/pages/lecture_manage_exercises/components.py
@@ -48,6 +48,7 @@ def new_tag_dialog():
                         ManageTagsState.add_new_tag,
                         None,
                     ),
+                    max_length=50,
                 ),
                 rx.hstack(
                     rx.dialog.close(
@@ -97,6 +98,7 @@ def rename_tag_dialog():
                         ManageTagsState.edit_tag_name(),
                         None,
                     ),
+                    max_length=50,
                 ),
                 rx.hstack(
                     rx.dialog.close(
@@ -775,6 +777,7 @@ def add_edit_exercise_form(mode: DialogMode) -> Sequence[rx.Component]:
             width="100%",
             type="text",
             name="title",
+            max_length=200,
         ),
         # description
         rx.text(
@@ -798,6 +801,7 @@ def add_edit_exercise_form(mode: DialogMode) -> Sequence[rx.Component]:
             height="150px",
             type="text",
             name="description",
+            max_length=5_000,
         ),
         # lesson context
         rx.text(
@@ -818,6 +822,7 @@ def add_edit_exercise_form(mode: DialogMode) -> Sequence[rx.Component]:
             height="200px",
             type="text",
             name="lesson_context",
+            max_length=10_000,
         ),
         # lesson file upload area
         pdf_upload(),
@@ -882,6 +887,7 @@ def add_edit_exercise_form(mode: DialogMode) -> Sequence[rx.Component]:
                             type="number",
                             step="1",
                             min="1",
+                            max_length=4,
                         ),
                     ),
                 ),


### PR DESCRIPTION
## Summary
Limit the text input from teh user to prevent harmful actions

## Changes

Added `max_length` properties to the following exercise and tag form fields:

| Field Name | Max Length / Limit |
|:---|:---|
| **Title** (`title`) | `200` characters |
| **Description** (`description`) | `5,000` characters |
| **Lesson Context** (`lesson_context`) | `10,000` characters |
| **Days to Complete** (`days_to_complete`) | `4` digits |
| **Tag Name** (`tag_name` in new & rename dialogs) | `50` characters |

## Testing
- go to `lectures/manage_exercises`
- try to insert text beyond the limits above 
- you should not be able to
