### PR TITLE
feat: limit the text input from users in chat report and search fields

### DIFF
--- a/aitutor/global_vars.py
+++ b/aitutor/global_vars.py
@@ -20,3 +20,12 @@ CHAT_MESSAGE_CHAR_LIMIT = 15000
 
 """colors"""
 GREEN_CHECK_COLOR = rx.color("green", 9)
+
+
+# --- max length for UI input fields ---
+
+# Auth
+USERNAME_MAX_LEN = 100
+EMAIL_MAX_LEN = 254
+PASSWORD_MAX_LEN = 128
+REGISTRATION_MAX_LEN = 150

--- a/aitutor/global_vars.py
+++ b/aitutor/global_vars.py
@@ -16,7 +16,6 @@ If the student answered correctly, you can write one sentence that the student a
 
 # ---- Chat related global variables ----
 CHAT_TOKEN_WARNING_THRESHOLD = 0.8  # Show warning at x% of limit
-CHAT_MESSAGE_CHAR_LIMIT = 15000
 
 """colors"""
 GREEN_CHECK_COLOR = rx.color("green", 9)
@@ -28,4 +27,11 @@ GREEN_CHECK_COLOR = rx.color("green", 9)
 USERNAME_MAX_LEN = 100
 EMAIL_MAX_LEN = 254
 PASSWORD_MAX_LEN = 128
-REGISTRATION_MAX_LEN = 150
+REGISTRATION_CODE_MAX_LEN = 150
+
+
+# Search
+SEARCH_TEXT_MAX_LEN = 150
+
+# Chat
+CHAT_MESSAGE_MAX_LEN = 15_000

--- a/aitutor/pages/all_lectures/components.py
+++ b/aitutor/pages/all_lectures/components.py
@@ -4,7 +4,11 @@ import reflex as rx
 
 from aitutor import routes
 from aitutor.language_state import LanguageState as LS
-from aitutor.pages.all_lectures.state import AllLecturesState, LectureWithRole
+from aitutor.pages.all_lectures.state import (
+    ALL_LECTURES_FIELD_MAX_LENGTHS,
+    AllLecturesState,
+    LectureWithRole,
+)
 
 
 def back_to_my_lectures_button() -> rx.Component:
@@ -156,6 +160,9 @@ def join_lecture_dialog() -> rx.Component:
                             placeholder=LS.registration_code_placeholder,
                             on_change=AllLecturesState.set_entered_registration_code,
                             width="100%",
+                            max_length=ALL_LECTURES_FIELD_MAX_LENGTHS[
+                                "registration_code"
+                            ],
                         ),
                         width="100%",
                         align="start",
@@ -200,6 +207,7 @@ def lectures_toolbar() -> rx.Component:
             on_change=AllLecturesState.update_search_text,
             width="22em",
             max_width="100%",
+            max_length=ALL_LECTURES_FIELD_MAX_LENGTHS["search_text"],
         ),
         width="85vw",
         max_width="100%",

--- a/aitutor/pages/all_lectures/state.py
+++ b/aitutor/pages/all_lectures/state.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import reflex as rx
 from sqlmodel import and_, select
 
+import aitutor.global_vars as GV
 import aitutor.routes as routes
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
@@ -12,6 +13,12 @@ from aitutor.language_state import BackendTranslations as BT
 from aitutor.models import Lecture, LectureRole, LinkUserLecture, UserRole
 
 LectureWithRole = tuple[Lecture, int | None]
+
+
+ALL_LECTURES_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "search_text": GV.SEARCH_TEXT_MAX_LEN,
+    "registration_code": GV.REGISTRATION_CODE_MAX_LEN,
+}
 
 
 class AllLecturesState(SessionState):
@@ -30,12 +37,14 @@ class AllLecturesState(SessionState):
     @rx.event
     def update_search_text(self, value: str):
         """Update the lecture search text."""
-        self.search_text = value
+        self.search_text = value[: ALL_LECTURES_FIELD_MAX_LENGTHS["search_text"]]
 
     @rx.event
     def set_entered_registration_code(self, value: str):
         """Update the entered registration code for the join dialog."""
-        self.entered_registration_code = value
+        self.entered_registration_code = value[
+            : ALL_LECTURES_FIELD_MAX_LENGTHS["registration_code"]
+        ]
 
     @rx.event
     def toggle_lecture_details(self, lecture_id: int):

--- a/aitutor/pages/chat/components.py
+++ b/aitutor/pages/chat/components.py
@@ -2,9 +2,9 @@
 
 import reflex as rx
 
-import aitutor.global_vars as gv
+import aitutor.global_vars as GV
 from aitutor.components.dialogs import confirm, destructive_confirm
-from aitutor.global_vars import CHAT_MESSAGE_CHAR_LIMIT
+from aitutor.global_vars import CHAT_MESSAGE_MAX_LEN
 from aitutor.language_state import LanguageState
 from aitutor.pages.chat.state import ChatMessage, ChatState, Role
 
@@ -110,7 +110,7 @@ def chat_form() -> rx.Component:
             enter_key_submit=with_key_submit,
             resize="vertical",
             rows="4",
-            max_length=CHAT_MESSAGE_CHAR_LIMIT,
+            max_length=CHAT_MESSAGE_MAX_LEN,
         )
 
     return rx.form(
@@ -331,6 +331,7 @@ def report_conversation_button() -> rx.Component:
                         on_change=ChatState.set_report_text,
                         width="100%",
                         rows="4",
+                        max_length=ChatState.MAX_REPORT_LENGTH,
                     ),
                     rx.text(
                         f"{ChatState.report_char_count} / "
@@ -399,7 +400,7 @@ def submitted_status() -> rx.Component:
         ),
         rx.icon(
             "circle-check",
-            color=gv.GREEN_CHECK_COLOR,
+            color=GV.GREEN_CHECK_COLOR,
             size=30,
         ),
         align="center",

--- a/aitutor/pages/chat/state.py
+++ b/aitutor/pages/chat/state.py
@@ -16,7 +16,7 @@ from aitutor.auth.state import SessionState
 from aitutor.config import get_config
 from aitutor.env_settings import get_env_settings
 from aitutor.global_vars import (
-    CHAT_MESSAGE_CHAR_LIMIT,
+    CHAT_MESSAGE_MAX_LEN,
     CHAT_TOKEN_WARNING_THRESHOLD,
     DEFAULT_CHECK_CONVERSATION_PROMPT,
     TIME_FORMAT,
@@ -197,12 +197,12 @@ class ChatState(SessionState):
     @rx.event
     def set_report_text(self, value: str):
         """Set the report text."""
-        self.report_text = value
+        self.report_text = value[: self.MAX_REPORT_LENGTH]
 
     @rx.event
     def set_user_input(self, value: str):
         """Sets the user input value. Truncates if over character limit."""
-        self.user_input = value[:CHAT_MESSAGE_CHAR_LIMIT]
+        self.user_input = value[:CHAT_MESSAGE_MAX_LEN]
 
     @rx.event
     @state_require_role_or_permission(required_role=UserRole.STUDENT)
@@ -442,8 +442,8 @@ class ChatState(SessionState):
             if self.waiting_for_response:
                 # don't allow sending another message while waiting for a response
                 return
-            if len(self.user_input) > CHAT_MESSAGE_CHAR_LIMIT:
-                self.user_input = self.user_input[:CHAT_MESSAGE_CHAR_LIMIT]
+            if len(self.user_input) > CHAT_MESSAGE_MAX_LEN:
+                self.user_input = self.user_input[:CHAT_MESSAGE_MAX_LEN]
                 return
             self.waiting_for_response = True
 

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -27,7 +27,7 @@ from aitutor.states.banner_state import (
 from aitutor.states.config_state import DisplayConfigState
 
 CONFIG_FIELD_MAX_LENGTHS: dict[str, int] = {
-    "registration_code": GV.REGISTRATION_MAX_LEN,
+    "registration_code": GV.REGISTRATION_CODE_MAX_LEN,
     "response_ai_model": 100,
     "check_ai_model": 100,
     "how_to_use_text": 10_000,

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 import reflex as rx
 from sqlmodel import select
 
+import aitutor.global_vars as GV
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.global_vars import TIME_ZONE
@@ -26,7 +27,7 @@ from aitutor.states.banner_state import (
 from aitutor.states.config_state import DisplayConfigState
 
 CONFIG_FIELD_MAX_LENGTHS: dict[str, int] = {
-    "registration_code": 150,
+    "registration_code": GV.REGISTRATION_MAX_LEN,
     "response_ai_model": 100,
     "check_ai_model": 100,
     "how_to_use_text": 10_000,

--- a/aitutor/pages/lecture_members/components.py
+++ b/aitutor/pages/lecture_members/components.py
@@ -6,6 +6,7 @@ from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import LectureRole
 from aitutor.pages.lecture_members.state import (
+    LECTURE_MEMBERS_FIELD_MAX_LENGTHS,
     AvailableLectureUser,
     LectureMemberRow,
     LectureMembersState,
@@ -120,6 +121,7 @@ def available_user_filter() -> rx.Component:
             on_change=LectureMembersState.set_available_user_filter_query,
             placeholder=LS.search_filter_placeholder,
             width="100%",
+            max_length=LECTURE_MEMBERS_FIELD_MAX_LENGTHS["available_user_filter_query"],
         ),
         rx.cond(
             LectureMembersState.available_user_filter_query != "",

--- a/aitutor/pages/lecture_members/state.py
+++ b/aitutor/pages/lecture_members/state.py
@@ -6,6 +6,7 @@ import reflex as rx
 from reflex_local_auth.user import LocalUser
 from sqlmodel import col, func, select
 
+import aitutor.global_vars as GV
 import aitutor.routes as routes
 from aitutor.auth.protection import state_require_lecture_role
 from aitutor.auth.state import SessionState
@@ -16,6 +17,10 @@ from aitutor.utilities.lecture_permissions import (
     get_user_lecture_link,
     user_may_view_lecture,
 )
+
+LECTURE_MEMBERS_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "available_user_filter_query": GV.USERNAME_MAX_LEN,
+}
 
 
 @dataclass
@@ -52,7 +57,9 @@ class LectureMembersState(SessionState):
     @rx.event
     def set_available_user_filter_query(self, query: str):
         """Set the user search query for the add-member dialog."""
-        self.available_user_filter_query = query
+        self.available_user_filter_query = query[
+            : LECTURE_MEMBERS_FIELD_MAX_LENGTHS["available_user_filter_query"]
+        ]
 
     @rx.event
     def clear_available_user_filter_query(self):

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -7,7 +7,10 @@ from reflex_local_auth.pages.components import MIN_WIDTH
 from aitutor import components, routes
 from aitutor.language_state import LanguageState
 from aitutor.pages.legal_infos.loader_functions import get_privacy_notice_short
-from aitutor.pages.login_and_registration.state import MyRegisterState
+from aitutor.pages.login_and_registration.state import (
+    AUTH_FIELD_MAX_LENGTHS,
+    MyRegisterState,
+)
 
 
 def input(name, placeholder, **props) -> rx.Component:
@@ -167,6 +170,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.username,
                 on_change=MyRegisterState.set_username,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["username"],
             ),
             rx.text(LanguageState.email),
             input(
@@ -178,6 +182,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.email,
                 on_change=MyRegisterState.set_email,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["email"],
             ),
             rx.text(LanguageState.password),
             password_input(
@@ -188,6 +193,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.password,
                 on_change=MyRegisterState.set_password,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["password"],
             ),
             rx.text(LanguageState.confirm_password),
             password_input(
@@ -198,6 +204,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.confirm_password,
                 on_change=MyRegisterState.set_confirm_password,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["confirm_password"],
             ),
             rx.cond(
                 MyRegisterState.needs_registration_code,
@@ -210,6 +217,7 @@ def register_form() -> rx.Component:
                         value=MyRegisterState.registration_code,
                         on_change=MyRegisterState.set_registration_code,
                         disabled=MyRegisterState.registration_in_progress,
+                        max_length=AUTH_FIELD_MAX_LENGTHS["registration_code"],
                     ),
                 ),
             ),

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -31,7 +31,7 @@ AUTH_FIELD_MAX_LENGTHS: dict[str, int] = {
     "email": GV.EMAIL_MAX_LEN,
     "password": GV.PASSWORD_MAX_LEN,
     "confirm_password": GV.PASSWORD_MAX_LEN,
-    "registration_code": GV.REGISTRATION_MAX_LEN,
+    "registration_code": GV.REGISTRATION_CODE_MAX_LEN,
 }
 
 

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -12,9 +12,9 @@ import reflex_local_auth
 from reflex_local_auth.user import LocalUser
 from sqlmodel import func, select
 
+import aitutor.global_vars as GV
 from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
-from aitutor.global_vars import TIME_ZONE
 from aitutor.language_state import language_from_value
 from aitutor.models import (
     GlobalPermission,
@@ -25,6 +25,14 @@ from aitutor.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+AUTH_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "username": GV.USERNAME_MAX_LEN,
+    "email": GV.EMAIL_MAX_LEN,
+    "password": GV.PASSWORD_MAX_LEN,
+    "confirm_password": GV.PASSWORD_MAX_LEN,
+    "registration_code": GV.REGISTRATION_MAX_LEN,
+}
 
 
 class MyLoginState(reflex_local_auth.LoginState):
@@ -61,27 +69,27 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     @rx.event
     def set_username(self, value: str):
         """Set the username."""
-        self.username = value
+        self.username = value[: AUTH_FIELD_MAX_LENGTHS["username"]]
 
     @rx.event
     def set_email(self, value: str):
         """Set the email."""
-        self.email = value
+        self.email = value[: AUTH_FIELD_MAX_LENGTHS["email"]]
 
     @rx.event
     def set_password(self, value: str):
         """Set the password."""
-        self.password = value
+        self.password = value[: AUTH_FIELD_MAX_LENGTHS["password"]]
 
     @rx.event
     def set_confirm_password(self, value: str):
         """Set the confirm password."""
-        self.confirm_password = value
+        self.confirm_password = value[: AUTH_FIELD_MAX_LENGTHS["confirm_password"]]
 
     @rx.event
     def set_registration_code(self, value: str):
         """Set the registration code."""
-        self.registration_code = value
+        self.registration_code = value[: AUTH_FIELD_MAX_LENGTHS["registration_code"]]
 
     @rx.event
     def on_load(self):
@@ -135,6 +143,11 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         yield
 
         try:
+            # set the max length of the strings
+            for field, max_len in AUTH_FIELD_MAX_LENGTHS.items():
+                if field in form_data and isinstance(form_data[field], str):
+                    form_data[field] = form_data[field][:max_len]
+
             language = language_from_value(form_data.get("language"))
             # check for allowed user name
             if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
@@ -247,7 +260,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         Returns:
             bool: True if the token is valid, False otherwise.
         """
-        now = datetime.now(ZoneInfo(TIME_ZONE))
+        now = datetime.now(ZoneInfo(GV.TIME_ZONE))
         with rx.session() as session:
             stmt = select(func.count()).where(
                 LecturerRegistrationToken.token == token,

--- a/aitutor/pages/manage_users/components.py
+++ b/aitutor/pages/manage_users/components.py
@@ -6,7 +6,10 @@ from aitutor.components import password_input
 from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import LocalUser, UserInfo, UserRole
-from aitutor.pages.manage_users.state import ManageUsersState
+from aitutor.pages.manage_users.state import (
+    MANAGE_USERS_FIELD_MAX_LENGTHS,
+    ManageUsersState,
+)
 
 
 def role_to_text(role: UserRole):
@@ -115,6 +118,7 @@ def edit_user_dialog() -> rx.Component:
                             width="100%",
                             type="text",
                             name="username",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["username"],
                         ),
                         form_label(LS.email),
                         rx.input(
@@ -123,6 +127,7 @@ def edit_user_dialog() -> rx.Component:
                             width="100%",
                             type="text",
                             name="email",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["email"],
                         ),
                         form_label(LS.new_password),
                         password_input(
@@ -130,6 +135,7 @@ def edit_user_dialog() -> rx.Component:
                             placeholder=LS.new_password_placeholder,
                             size="3",
                             width="100%",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["new_password"],
                         ),
                         form_label(LS.role),
                         rx.hstack(

--- a/aitutor/pages/manage_users/state.py
+++ b/aitutor/pages/manage_users/state.py
@@ -4,6 +4,7 @@ import reflex as rx
 from reflex_local_auth.auth_session import LocalAuthSession
 from sqlmodel import case, cast, select
 
+import aitutor.global_vars as GV
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.language_state import BackendTranslations as BT
@@ -16,6 +17,12 @@ from aitutor.models import (
     UserInfo,
     UserRole,
 )
+
+MANAGE_USERS_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "username": GV.USERNAME_MAX_LEN,
+    "email": GV.EMAIL_MAX_LEN,
+    "new_password": GV.PASSWORD_MAX_LEN,
+}
 
 
 class ManageUsersState(SessionState):
@@ -110,6 +117,11 @@ class ManageUsersState(SessionState):
     def update_user(self, form_data):
         """Save changes to a user from the edit form."""
         assert self.edited_user is not None
+        # set max length for strings from UserInfo
+        for field, max_length in MANAGE_USERS_FIELD_MAX_LENGTHS.items():
+            if field in form_data:
+                form_data[field] = form_data[field][:max_length]
+
         with rx.session() as session:
             query = (
                 select(LocalUser, UserInfo)

--- a/aitutor/pages/my_lectures/components.py
+++ b/aitutor/pages/my_lectures/components.py
@@ -7,6 +7,7 @@ from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import Lecture, LectureRole
 from aitutor.pages.my_lectures.state import (
+    MY_LECTURES_FIELD_MAX_LENGTHS,
     ROLE_FILTER_ALL,
     ROLE_FILTER_NOT_JOINED,
     ROLE_FILTER_OWNER,
@@ -219,6 +220,7 @@ def lectures_toolbar() -> rx.Component:
         on_change=MyLecturesState.update_search_text,
         width="22em",
         max_width="100%",
+        max_length=MY_LECTURES_FIELD_MAX_LENGTHS["search_text"],
     )
     action_buttons = rx.hstack(
         rx.box(browse_lectures_button(), flex_shrink="0"),
@@ -255,6 +257,7 @@ def lectures_toolbar() -> rx.Component:
                         placeholder=LS.search_placeholder,
                         on_change=MyLecturesState.update_search_text,
                         width="100%",
+                        max_length=MY_LECTURES_FIELD_MAX_LENGTHS["search_text"],
                     ),
                     rx.box(role_filter_select(), width="100%"),
                     action_buttons,

--- a/aitutor/pages/my_lectures/state.py
+++ b/aitutor/pages/my_lectures/state.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import reflex as rx
 from sqlmodel import and_, select
 
+import aitutor.global_vars as GV
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.language_state import BackendTranslations as BT
@@ -19,6 +20,10 @@ from aitutor.utilities.lecture_permissions import (
     count_lecture_owners,
     get_user_lecture_link,
 )
+
+MY_LECTURES_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "search_text": GV.SEARCH_TEXT_MAX_LEN,
+}
 
 LectureWithRole = tuple[Lecture, int | None]
 
@@ -39,7 +44,7 @@ class MyLecturesState(SessionState):
     @rx.event
     def update_search_text(self, value: str):
         """Update the lecture name search text."""
-        self.search_text = value
+        self.search_text = value[: MY_LECTURES_FIELD_MAX_LENGTHS["search_text"]]
 
     @rx.event
     def set_role_filter(self, value: str):

--- a/aitutor/utilities/filtering_components.py
+++ b/aitutor/utilities/filtering_components.py
@@ -10,6 +10,7 @@ from aitutor.global_vars import (
     SEARCH_EXERCISE_KEY,
     SEARCH_EXERCISE_TITLE_KEY,
     SEARCH_TAG_KEY,
+    SEARCH_TEXT_MAX_LEN,
     SEARCH_USER_KEY,
 )
 from aitutor.language_state import LanguageState
@@ -34,7 +35,8 @@ class FilterMixin(rx.State, mixin=True):
     @rx.event
     def add_search_value(self, form_data: dict):
         """Adds a search value to the list of search values."""
-        parsed = parse_query_keys(form_data["search_value"], self.search_keys)
+        raw_val = form_data["search_value"][:SEARCH_TEXT_MAX_LEN]
+        parsed = parse_query_keys(raw_val, self.search_keys)
         if parsed not in self.search_values:
             self.search_values.append(parsed)
         self.load_filtered_data()
@@ -77,6 +79,7 @@ def search_bar(state: type[FilterMixin]) -> rx.Component:
                 placeholder=LanguageState.search_placeholder,
                 required=True,
                 max_width="60vw",
+                max_length=SEARCH_TEXT_MAX_LEN,
             ),
             rx.button(
                 rx.icon("plus"),


### PR DESCRIPTION
## Summary

Limit the text input from the user to prevent harmful actions, ensure clean database records, and prevent oversized search payloads.

Added frontend input limits (`max_length`) and corresponding backend checks/clamping (`*_FIELD_MAX_LENGTHS`) `[NEW]`.
Centralized search and chat limits into `aitutor.global_vars` (`GV.*`) to avoid hardcoded values across pages `[NEW]`.

## Changes

Added length limits to the following chat report and search filter fields:

| Field Name | Max Length / Limit |
|:---|:---|
| **Report Problematic Chat** (`report_text`) | `2,000` characters (`ChatState.MAX_REPORT_LENGTH`) |
| **Chat User Message** (`user_input`) `[NEW]` | `15,000` characters (`GV.CHAT_MESSAGE_MAX_LEN`) |
| **My Lectures Search** (`search_text` desktop & mobile) | `150` characters (`GV.SEARCH_TEXT_MAX_LEN`) |
| **All Lectures Search** (`search_text`) | `150` characters (`GV.SEARCH_TEXT_MAX_LEN`) |
| **All Lectures Join Registration Code** (`entered_registration_code`) `[NEW]` | `150` characters (`GV.REGISTRATION_CODE_MAX_LEN`) |
| **Generic Filter Search Bar** (`search_value`) | `150` characters (`GV.SEARCH_TEXT_MAX_LEN`) |

- `[NEW]` Backend checks: Added length validation and clamping (`*_FIELD_MAX_LENGTHS`) across all search handlers, join registration code, and chat report.
- `[NEW]` Centralized `SEARCH_TEXT_MAX_LEN` and `CHAT_MESSAGE_MAX_LEN` into `aitutor/global_vars.py`.
- `[NEW]` Added `max_length` and backend check for `entered_registration_code` in the All Lectures join dialog.
- `[NEW]` Added backend truncation in `FilterMixin.add_search_value` to guard table searches.

## Testing

- go to `/chat/[exercise_id]`, click the flag report icon, and verify the report textarea blocks input beyond 2,000 characters
- go to `/lectures/my_lectures` and test the search bar input limit (150 chars)
- go to `/lectures/all_lectures` and test the search bar input limit (150 chars) and join registration code limit (150 chars)
- go to `/lectures/exercises/[lecture_id]` and test the filter bar input limit (150 chars)
- you should not be able to exceed these limits