### PR TITLE
feat: limit the text input from users in user and member management pages

### DIFF
--- a/aitutor/global_vars.py
+++ b/aitutor/global_vars.py
@@ -20,3 +20,12 @@ CHAT_MESSAGE_CHAR_LIMIT = 15000
 
 """colors"""
 GREEN_CHECK_COLOR = rx.color("green", 9)
+
+
+# --- max length for UI input fields ---
+
+# Auth
+USERNAME_MAX_LEN = 100
+EMAIL_MAX_LEN = 254
+PASSWORD_MAX_LEN = 128
+REGISTRATION_MAX_LEN = 150

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 import reflex as rx
 from sqlmodel import select
 
+import aitutor.global_vars as GV
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.global_vars import TIME_ZONE
@@ -26,7 +27,7 @@ from aitutor.states.banner_state import (
 from aitutor.states.config_state import DisplayConfigState
 
 CONFIG_FIELD_MAX_LENGTHS: dict[str, int] = {
-    "registration_code": 150,
+    "registration_code": GV.REGISTRATION_MAX_LEN,
     "response_ai_model": 100,
     "check_ai_model": 100,
     "how_to_use_text": 10_000,

--- a/aitutor/pages/lecture_members/components.py
+++ b/aitutor/pages/lecture_members/components.py
@@ -6,6 +6,7 @@ from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import LectureRole
 from aitutor.pages.lecture_members.state import (
+    LECTURE_MEMBERS_FIELD_MAX_LENGTHS,
     AvailableLectureUser,
     LectureMemberRow,
     LectureMembersState,
@@ -120,6 +121,7 @@ def available_user_filter() -> rx.Component:
             on_change=LectureMembersState.set_available_user_filter_query,
             placeholder=LS.search_filter_placeholder,
             width="100%",
+            max_length=LECTURE_MEMBERS_FIELD_MAX_LENGTHS["available_user_filter_query"],
         ),
         rx.cond(
             LectureMembersState.available_user_filter_query != "",

--- a/aitutor/pages/lecture_members/state.py
+++ b/aitutor/pages/lecture_members/state.py
@@ -6,6 +6,7 @@ import reflex as rx
 from reflex_local_auth.user import LocalUser
 from sqlmodel import col, func, select
 
+import aitutor.global_vars as GV
 import aitutor.routes as routes
 from aitutor.auth.protection import state_require_lecture_role
 from aitutor.auth.state import SessionState
@@ -16,6 +17,10 @@ from aitutor.utilities.lecture_permissions import (
     get_user_lecture_link,
     user_may_view_lecture,
 )
+
+LECTURE_MEMBERS_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "available_user_filter_query": GV.USERNAME_MAX_LEN,
+}
 
 
 @dataclass
@@ -52,7 +57,9 @@ class LectureMembersState(SessionState):
     @rx.event
     def set_available_user_filter_query(self, query: str):
         """Set the user search query for the add-member dialog."""
-        self.available_user_filter_query = query
+        self.available_user_filter_query = query[
+            : LECTURE_MEMBERS_FIELD_MAX_LENGTHS["available_user_filter_query"]
+        ]
 
     @rx.event
     def clear_available_user_filter_query(self):

--- a/aitutor/pages/login_and_registration/components.py
+++ b/aitutor/pages/login_and_registration/components.py
@@ -7,7 +7,10 @@ from reflex_local_auth.pages.components import MIN_WIDTH
 from aitutor import components, routes
 from aitutor.language_state import LanguageState
 from aitutor.pages.legal_infos.loader_functions import get_privacy_notice_short
-from aitutor.pages.login_and_registration.state import MyRegisterState
+from aitutor.pages.login_and_registration.state import (
+    AUTH_FIELD_MAX_LENGTHS,
+    MyRegisterState,
+)
 
 
 def input(name, placeholder, **props) -> rx.Component:
@@ -167,6 +170,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.username,
                 on_change=MyRegisterState.set_username,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["username"],
             ),
             rx.text(LanguageState.email),
             input(
@@ -178,6 +182,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.email,
                 on_change=MyRegisterState.set_email,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["email"],
             ),
             rx.text(LanguageState.password),
             password_input(
@@ -188,6 +193,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.password,
                 on_change=MyRegisterState.set_password,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["password"],
             ),
             rx.text(LanguageState.confirm_password),
             password_input(
@@ -198,6 +204,7 @@ def register_form() -> rx.Component:
                 value=MyRegisterState.confirm_password,
                 on_change=MyRegisterState.set_confirm_password,
                 disabled=MyRegisterState.registration_in_progress,
+                max_length=AUTH_FIELD_MAX_LENGTHS["confirm_password"],
             ),
             rx.cond(
                 MyRegisterState.needs_registration_code,
@@ -210,6 +217,7 @@ def register_form() -> rx.Component:
                         value=MyRegisterState.registration_code,
                         on_change=MyRegisterState.set_registration_code,
                         disabled=MyRegisterState.registration_in_progress,
+                        max_length=AUTH_FIELD_MAX_LENGTHS["registration_code"],
                     ),
                 ),
             ),

--- a/aitutor/pages/login_and_registration/state.py
+++ b/aitutor/pages/login_and_registration/state.py
@@ -12,9 +12,9 @@ import reflex_local_auth
 from reflex_local_auth.user import LocalUser
 from sqlmodel import func, select
 
+import aitutor.global_vars as GV
 from aitutor.account_emails import send_signup_welcome_email
 from aitutor.config import get_config
-from aitutor.global_vars import TIME_ZONE
 from aitutor.language_state import language_from_value
 from aitutor.models import (
     GlobalPermission,
@@ -25,6 +25,14 @@ from aitutor.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+AUTH_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "username": GV.USERNAME_MAX_LEN,
+    "email": GV.EMAIL_MAX_LEN,
+    "password": GV.PASSWORD_MAX_LEN,
+    "confirm_password": GV.PASSWORD_MAX_LEN,
+    "registration_code": GV.REGISTRATION_MAX_LEN,
+}
 
 
 class MyLoginState(reflex_local_auth.LoginState):
@@ -61,27 +69,27 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
     @rx.event
     def set_username(self, value: str):
         """Set the username."""
-        self.username = value
+        self.username = value[: AUTH_FIELD_MAX_LENGTHS["username"]]
 
     @rx.event
     def set_email(self, value: str):
         """Set the email."""
-        self.email = value
+        self.email = value[: AUTH_FIELD_MAX_LENGTHS["email"]]
 
     @rx.event
     def set_password(self, value: str):
         """Set the password."""
-        self.password = value
+        self.password = value[: AUTH_FIELD_MAX_LENGTHS["password"]]
 
     @rx.event
     def set_confirm_password(self, value: str):
         """Set the confirm password."""
-        self.confirm_password = value
+        self.confirm_password = value[: AUTH_FIELD_MAX_LENGTHS["confirm_password"]]
 
     @rx.event
     def set_registration_code(self, value: str):
         """Set the registration code."""
-        self.registration_code = value
+        self.registration_code = value[: AUTH_FIELD_MAX_LENGTHS["registration_code"]]
 
     @rx.event
     def on_load(self):
@@ -135,6 +143,11 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         yield
 
         try:
+            # set the max length of the strings
+            for field, max_len in AUTH_FIELD_MAX_LENGTHS.items():
+                if field in form_data and isinstance(form_data[field], str):
+                    form_data[field] = form_data[field][:max_len]
+
             language = language_from_value(form_data.get("language"))
             # check for allowed user name
             if not re.match(r"^[a-zA-Z0-9._-]+$", form_data["username"]):
@@ -247,7 +260,7 @@ class MyRegisterState(reflex_local_auth.RegistrationState):
         Returns:
             bool: True if the token is valid, False otherwise.
         """
-        now = datetime.now(ZoneInfo(TIME_ZONE))
+        now = datetime.now(ZoneInfo(GV.TIME_ZONE))
         with rx.session() as session:
             stmt = select(func.count()).where(
                 LecturerRegistrationToken.token == token,

--- a/aitutor/pages/manage_users/components.py
+++ b/aitutor/pages/manage_users/components.py
@@ -6,7 +6,10 @@ from aitutor.components import password_input
 from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import LocalUser, UserInfo, UserRole
-from aitutor.pages.manage_users.state import ManageUsersState
+from aitutor.pages.manage_users.state import (
+    MANAGE_USERS_FIELD_MAX_LENGTHS,
+    ManageUsersState,
+)
 
 
 def role_to_text(role: UserRole):
@@ -115,6 +118,7 @@ def edit_user_dialog() -> rx.Component:
                             width="100%",
                             type="text",
                             name="username",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["username"],
                         ),
                         form_label(LS.email),
                         rx.input(
@@ -123,6 +127,7 @@ def edit_user_dialog() -> rx.Component:
                             width="100%",
                             type="text",
                             name="email",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["email"],
                         ),
                         form_label(LS.new_password),
                         password_input(
@@ -130,6 +135,7 @@ def edit_user_dialog() -> rx.Component:
                             placeholder=LS.new_password_placeholder,
                             size="3",
                             width="100%",
+                            max_length=MANAGE_USERS_FIELD_MAX_LENGTHS["new_password"],
                         ),
                         form_label(LS.role),
                         rx.hstack(

--- a/aitutor/pages/manage_users/state.py
+++ b/aitutor/pages/manage_users/state.py
@@ -4,6 +4,7 @@ import reflex as rx
 from reflex_local_auth.auth_session import LocalAuthSession
 from sqlmodel import case, cast, select
 
+import aitutor.global_vars as GV
 from aitutor.auth.protection import state_require_role_or_permission
 from aitutor.auth.state import SessionState
 from aitutor.language_state import BackendTranslations as BT
@@ -16,6 +17,12 @@ from aitutor.models import (
     UserInfo,
     UserRole,
 )
+
+MANAGE_USERS_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "username": GV.USERNAME_MAX_LEN,
+    "email": GV.EMAIL_MAX_LEN,
+    "new_password": GV.PASSWORD_MAX_LEN,
+}
 
 
 class ManageUsersState(SessionState):
@@ -110,6 +117,11 @@ class ManageUsersState(SessionState):
     def update_user(self, form_data):
         """Save changes to a user from the edit form."""
         assert self.edited_user is not None
+        # set max length for strings from UserInfo
+        for field, max_length in MANAGE_USERS_FIELD_MAX_LENGTHS.items():
+            if field in form_data:
+                form_data[field] = form_data[field][:max_length]
+
         with rx.session() as session:
             query = (
                 select(LocalUser, UserInfo)


### PR DESCRIPTION
## Summary

Limit the text input from the user to prevent harmful actions, enforce standard email/username boundaries, and ensure clean database records.

Added frontend input limits (`max_length`) and corresponding backend checks/clamping (`*_FIELD_MAX_LENGTHS`) `[NEW]`.
Centralized input field length constants into `aitutor.global_vars` (`GV.*`) to avoid mismatches across pages `[NEW]`.

## Changes

Added length limits to the following user and member management form fields:

| Field Name | Max Length / Limit |
|:---|:---|
| **Username** (`username`) | `100` characters (`GV.USERNAME_MAX_LEN`) |
| **Email** (`email`) | `254` characters (`GV.EMAIL_MAX_LEN`) |
| **Password & Confirm Password** (`password`) | `128` characters (`GV.PASSWORD_MAX_LEN`) |
| **New Password** (`new_password`) `[NEW]` | `128` characters (`GV.PASSWORD_MAX_LEN`) |
| **Registration Code** (`registration_code`) | `150` characters (`GV.REGISTRATION_MAX_LEN`) |
| **Available User Search Filter** (`available_user_filter_query`) | `100` characters (`GV.USERNAME_MAX_LEN`) |

- `[NEW]` Centralized authentication and input limit constants in `aitutor/global_vars.py` (`USERNAME_MAX_LEN`, `EMAIL_MAX_LEN`, `PASSWORD_MAX_LEN`, `REGISTRATION_MAX_LEN`).
- `[NEW]` Updated `aitutor/pages/configuration/state.py` (file in main) to use `GV.REGISTRATION_MAX_LEN` to keep limits synchronized across the app.
- `[NEW]` Added `max_length=128` to **New Password** in the edit user dialog.
- `[NEW]` Backend checks: Added length validation and clamping (`*_FIELD_MAX_LENGTHS`) across all fields.

## Testing

- go to `/register` and test input limits on username, email, password, and registration code
- go to `/admin_settings/manage_users`, click edit on a user, and verify username, email, and new password inputs block text exceeding the limits
- go to `/lectures/members/[lecture_id]`, open Add Member dialog, and test the user search input limit (100 chars)
- go to `/admin_settings/configuration` and verify registration code field still works with the global limit
- you should not be able to exceed these limits