### PR TITLE
feat: limit the text input from users in configuration page

### DIFF
--- a/aitutor/pages/configuration/components.py
+++ b/aitutor/pages/configuration/components.py
@@ -8,6 +8,7 @@ from aitutor.components.dialogs import destructive_confirm
 from aitutor.language_state import LanguageState as LS
 from aitutor.models import BannerMessageType, LecturerRegistrationToken
 from aitutor.pages.configuration.state import (
+    CONFIG_FIELD_MAX_LENGTHS,
     LecturerRegistrationTokenState,
     ManageConfigState,
 )
@@ -174,6 +175,7 @@ def config_form() -> rx.Component:
                         "registration_code", value
                     ),
                     info=info_icon(LS.registration_code_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["registration_code"],
                 ),
                 input(
                     name="response_ai_model",
@@ -183,6 +185,7 @@ def config_form() -> rx.Component:
                         "response_ai_model", value
                     ),
                     info=info_icon(LS.response_ai_model_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["response_ai_model"],
                 ),
                 input(
                     name="check_ai_model",
@@ -192,6 +195,7 @@ def config_form() -> rx.Component:
                         "check_ai_model", value
                     ),
                     info=info_icon(LS.check_ai_model_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["check_ai_model"],
                 ),
                 input(
                     name="exercise_token_limit",
@@ -210,6 +214,7 @@ def config_form() -> rx.Component:
                         "how_to_use_text", value
                     ),
                     info=info_icon(LS.info_texts_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["how_to_use_text"],
                 ),
                 text_area(
                     name="general_info_text",
@@ -219,6 +224,7 @@ def config_form() -> rx.Component:
                         "general_information_text", value
                     ),
                     info=info_icon(LS.info_texts_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["general_information_text"],
                 ),
                 text_area(
                     name="impressum",
@@ -228,6 +234,7 @@ def config_form() -> rx.Component:
                         "impressum_text", value
                     ),
                     info=info_icon(LS.impressum_info),
+                    max_length=CONFIG_FIELD_MAX_LENGTHS["impressum_text"],
                 ),
                 banner_form_group(),
                 rx.cond(

--- a/aitutor/pages/configuration/state.py
+++ b/aitutor/pages/configuration/state.py
@@ -25,6 +25,15 @@ from aitutor.states.banner_state import (
 )
 from aitutor.states.config_state import DisplayConfigState
 
+CONFIG_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "registration_code": 150,
+    "response_ai_model": 100,
+    "check_ai_model": 100,
+    "how_to_use_text": 10_000,
+    "general_information_text": 10_000,
+    "impressum_text": 10_000,
+}
+
 empty_config: Config = Config(
     id=None,
     response_ai_model="failed to load!",
@@ -59,6 +68,9 @@ class ManageConfigState(SessionState):
     @rx.event
     def set_config_value(self, name: str, value: str):
         """Sets a configuration value in the current config."""
+        # set max length for input fields coming from UI
+        if name in CONFIG_FIELD_MAX_LENGTHS:
+            value = value[: CONFIG_FIELD_MAX_LENGTHS[name]]
         setattr(self.current_config, name, value)
         self.unsaved_changes = True
 


### PR DESCRIPTION
## Summary

Limit the text input from the user on the Global Configuration page to prevent oversized payloads and ensure clean database records.

Added frontend input limits (`max_length`) and corresponding backend checks/clamping (`CONFIG_FIELD_MAX_LENGTHS`) `[NEW]`.

## Changes

Added length limits to the following configuration form fields:

| Field Name | Max Length / Limit |
|:---|:---|
| **Registration Code** (`registration_code`) | `150` characters |
| **Response AI Model** (`response_ai_model`) | `100` characters |
| **Check AI Model** (`check_ai_model`) | `100` characters |
| **How to Use Text** (`how_to_use_text`) | `10,000` characters |
| **General Information Text** (`general_info_text` / `general_information_text`) | `10,000` characters |
| **Impressum Text** (`impressum` / `impressum_text`) | `10,000` characters |

- `[NEW]` Frontend limits: Added `max_length` attributes across configuration inputs and text areas using `CONFIG_FIELD_MAX_LENGTHS`.
- `[NEW]` Backend checks: Added length truncation and clamping in `ManageConfigState.set_config_value` via `CONFIG_FIELD_MAX_LENGTHS`.

## Testing

- go to `/admin_settings/configuration`
- try to insert text beyond the limits above into the model names, registration code, and text areas
- verify the inputs block text exceeding the limits
- verify saving properly stores and caps configuration values