### PR TITLE
clean front end from is none

### DIFF
--- a/aitutor/auth/protection.py
+++ b/aitutor/auth/protection.py
@@ -61,7 +61,8 @@ def lecture_has_role_at_least(role) -> rx.vars.Var[bool]:
     ADMIN permission.
     """
     return (
-        SessionState.user_role is not None and SessionState.user_role >= role
+        (SessionState.user_role != None)  # noqa: E711
+        & (SessionState.user_role >= role)
     ) | SessionState.global_permissions.contains(GlobalPermission.ADMIN)
 
 

--- a/aitutor/pages/lecture_reports/components.py
+++ b/aitutor/pages/lecture_reports/components.py
@@ -81,9 +81,11 @@ def show_table_row(table_row: LectureReportTableRow) -> rx.Component:
                         ),
                         variant="ghost",
                         on_click=LectureReportsState.toggle_looked_at(
-                            table_row.report_id
-                            if table_row.report_id is not None
-                            else 0
+                            rx.cond(
+                                table_row.report_id != None,  # noqa: E711
+                                table_row.report_id,
+                                0,
+                            ).to(int)
                         ),
                         _hover={"cursor": "pointer"},
                     )
@@ -121,7 +123,11 @@ def show_table_row(table_row: LectureReportTableRow) -> rx.Component:
                 confirm_text=LanguageState.delete,
                 cancel_text=LanguageState.cancel,
                 on_confirm=LectureReportsState.delete_report(
-                    table_row.report_id if table_row.report_id is not None else 0
+                    rx.cond(
+                        table_row.report_id != None,  # noqa: E711
+                        table_row.report_id,
+                        0,
+                    ).to(int)
                 ),
                 trigger=rx.icon_button(
                     rx.icon("trash"),

--- a/aitutor/pages/my_lectures/components.py
+++ b/aitutor/pages/my_lectures/components.py
@@ -143,13 +143,12 @@ def browse_lectures_button() -> rx.Component:
 
 def leave_lecture_button(lecture: Lecture, *, width: str | None = None) -> rx.Component:
     """Render the leave lecture button with a destructive confirmation dialog."""
-    assert lecture.id is not None, "Lecture must be persisted to render leave button."
     return destructive_confirm(
         title=LS.leave_lecture + ": " + lecture.lecture_name,
         description=LS.leave_lecture_description,
         confirm_text=LS.leave_lecture,
         cancel_text=LS.cancel,
-        on_confirm=MyLecturesState.leave_lecture(lecture.id),
+        on_confirm=MyLecturesState.leave_lecture(lecture.id),  # type: ignore[arg-type]
         trigger=rx.button(
             rx.flex(
                 rx.icon("log-out", size=15),
@@ -167,7 +166,6 @@ def leave_lecture_button(lecture: Lecture, *, width: str | None = None) -> rx.Co
 
 def enter_lecture_button(lecture: Lecture, *, width: str | None = None) -> rx.Component:
     """Render the button for entering a lecture."""
-    assert lecture.id is not None, "Lecture must be persisted to render enter button."
     return rx.link(
         rx.button(
             rx.flex(


### PR DESCRIPTION
## Summary

Fix Reflex frontend expressions that incorrectly used Python-side `is not None`, boolean operators, and assertions with reactive variables.

## Changes

- Replace Python boolean logic with Reflex-compatible reactive expressions for lecture role checks.
- Use `rx.cond` when handling optional report IDs.
- Remove frontend assertions on reactive lecture IDs to prevent component rendering issues.
