### PR TITLE
Bump version to 2.0.0a1 and show version in footer

### DIFF
--- a/aitutor/_version.py
+++ b/aitutor/_version.py
@@ -1,0 +1,1 @@
+version: str = "2.0.0a1"

--- a/aitutor/pages/navbar.py
+++ b/aitutor/pages/navbar.py
@@ -8,6 +8,7 @@ from typing import Optional
 import reflex as rx
 
 import aitutor.routes as routes
+from aitutor._version import version
 from aitutor.auth.protection import has_permission, lecture_has_role_at_least
 from aitutor.auth.state import SessionState
 from aitutor.components import announcement_banner
@@ -364,6 +365,8 @@ def legal_footer() -> rx.Component:
     """Render the globally available legal links at the bottom of each page."""
     return rx.center(
         rx.hstack(
+            rx.text(f"AI Tutor v{version}", color=rx.color("gray", 9)),
+            rx.separator(orientation="vertical", height="1em"),
             rx.link(LanguageState.impressum, href=routes.IMPRESSUM),
             rx.link(LanguageState.privacy_notice, href=routes.PRIVACY_NOTICE),
             spacing="4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aitutor"
-version = "0.1.0"
+version = "2.0.0a1"
 description = "AI tutoring tool for interactive learning"
 authors = [
     {name = "AL Group", email = "georg.martius@uni-tuebingen.de"},

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.14"
 
 [[package]]
 name = "aitutor"
-version = "0.1.0"
+version = "2.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Helper script to bump package version and sychronize pyproject.toml with
+# aitutor/_version.py.
+# This may be obsolete if https://github.com/astral-sh/uv/issues/13827 gets
+# implemented.
+
+# bump version using given arguments (no arguments just print the current
+# version)
+uv version "$@"
+
+# if arguments were given, assume a bump and update the variable in
+# aitutor/_version.py
+if [ "$#" -gt 0 ]; then
+    echo "Update aitutor/_version.py with new version"
+    VERSION=$(uv version --short)
+    echo "version: str = \"$VERSION\"" > aitutor/_version.py
+fi


### PR DESCRIPTION
- Add a helper script `version.sh` to more easily update the version.  It runs `uv version` and updates a file `aitutor/_version.py`, so we can also access the version from within the code.
- Bump version to 2.0.0a1
- Show the version in the footer of all pages, so we can easily see which version is running, e.g. on a server.